### PR TITLE
safrequire polish: docs, changelog, docgram regeneration, rocqdep test, broader test coverage

### DIFF
--- a/doc/changelog/08-vernac-commands-and-options/22291-safe-require.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22291-safe-require.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  :cmd:`Require` :n:`(safe)` loads a library and its dependencies with only
+  kernel-level content and fully-qualified names: no plugins, notations, hints,
+  or flag settings are replayed. This is suitable for handling untrusted or
+  heavyweight libraries. A later plain :cmd:`Require` of a safe-loaded library
+  errors
+  (`#22291 <https://github.com/rocq-prover/rocq/pull/22291>`_,
+  by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -730,6 +730,47 @@ file is a particular case of a module called a *library file*.
 
       .. seealso:: Chapter :ref:`therocqcommands`
 
+.. cmd:: {? From @dirpath } Require ( safe ) {+ @qualid }
+   :name: Require (safe); From … Require (safe)
+
+   Loads a compiled file and all the files it depends on (recursively),
+   but only the kernel-level content is made available: the constants,
+   inductive types, constructors and modules that the library adds to the
+   kernel environment.  The libraries are located and their names resolved
+   exactly as for plain :cmd:`Require` (including the optional :n:`From @dirpath`
+   clause), but *no* :term:`libobject` is replayed.  In particular, this form
+   does not load any notation, coercion, hint, canonical structure, implicit
+   argument, ``ML`` plugin, or flag setting from the required libraries.
+
+   This is intended for loading untrusted or heavyweight libraries: since
+   nothing but the kernel content is processed, ill-behaved side effects of a
+   library (for instance abusive notations or flag changes) cannot affect the
+   current document, while its definitions can still be type-checked and used.
+
+   The loaded objects are only accessible through their *fully-qualified*
+   names; short names are not registered.  For example, after
+   `Require (safe) Corelib.Classes.CRelationClasses.` the constant is available
+   as :n:`Corelib.Classes.CRelationClasses.flip` (and, since local loadpaths
+   are searched, typically also as the shorter qualified prefixes) but not as
+   the bare `flip`.  There is no way to shorten these names with this command,
+   as :cmd:`Import` and :cmd:`Export` are not (yet) supported in this form.
+
+   Constants and inductive types loaded this way can be printed with
+   :cmd:`Print`, inspected with :cmd:`About` and :cmd:`Check`, located with
+   :cmd:`Locate`, used in terms, and their axioms reported by
+   :cmd:`Print Assumptions`.  The universe constraints they rely on are loaded,
+   so terms mentioning them typecheck.
+
+   A given library may be safe-required and later safe-required again (this is
+   a no-op), but a safe-loaded library cannot subsequently be loaded with a
+   plain :cmd:`Require`.
+
+   .. exn:: Cannot unsafe-require library @qualid because it was previously required with (safe).
+
+      A plain :cmd:`Require` was used on a library that had already been loaded
+      with :cmd:`Require (safe)`.  Loading only the kernel content and then
+      replaying the full library object is not supported.
+
 .. cmd:: Print Libraries
 
    This command displays the list of library files loaded in the

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -733,43 +733,44 @@ file is a particular case of a module called a *library file*.
 .. cmd:: {? From @dirpath } Require ( safe ) {+ @qualid }
    :name: Require (safe); From … Require (safe)
 
-   Loads a compiled file and all the files it depends on (recursively),
-   but only the kernel-level content is made available: the constants,
-   inductive types, constructors and modules that the library adds to the
-   kernel environment.  The libraries are located and their names resolved
-   exactly as for plain :cmd:`Require` (including the optional :n:`From @dirpath`
-   clause), but *no* :term:`libobject` is replayed.  In particular, this form
-   does not load any notation, coercion, hint, canonical structure, implicit
-   argument, ``ML`` plugin, or flag setting from the required libraries.
+   Like :cmd:`Require`, but loads only what the kernel needs to typecheck
+   terms using the libraries: the constants, inductive types, constructors,
+   modules, module types and universes they add to the :term:`global
+   environment`.  None of the conveniences that libraries provide for
+   parsing, elaboration, printing and automation are loaded: no notation,
+   coercion, hint, canonical structure, :cmd:`Arguments` information
+   (implicit arguments, argument scopes, reduction behavior), OCaml plugin
+   or flag setting.  Loaded references can otherwise be used like any other
+   reference; for instance, arguments that the library declares implicit
+   must be given explicitly.
 
-   This is intended for loading untrusted or heavyweight libraries: since
-   nothing but the kernel content is processed, ill-behaved side effects of a
-   library (for instance abusive notations or flag changes) cannot affect the
-   current document, while its definitions can still be type-checked and used.
+   Names are accessible as after a plain :cmd:`Require` not followed by
+   :cmd:`Import` — qualified at least by the name of the file that defines
+   them — and cannot be shortened further, since :cmd:`Import` and
+   :cmd:`Export` are not supported for safe-required libraries.
 
-   The loaded objects are only accessible through their *fully-qualified*
-   names; short names are not registered.  For example, after
-   `Require (safe) Corelib.Classes.CRelationClasses.` the constant is available
-   as :n:`Corelib.Classes.CRelationClasses.flip` (and, since local loadpaths
-   are searched, typically also as the shorter qualified prefixes) but not as
-   the bare `flip`.  There is no way to shorten these names with this command,
-   as :cmd:`Import` and :cmd:`Export` are not (yet) supported in this form.
+   .. rocqtop:: reset all
 
-   Constants and inductive types loaded this way can be printed with
-   :cmd:`Print`, inspected with :cmd:`About` and :cmd:`Check`, located with
-   :cmd:`Locate`, used in terms, and their axioms reported by
-   :cmd:`Print Assumptions`.  The universe constraints they rely on are loaded,
-   so terms mentioning them typecheck.
+      Require (safe) Corelib.Classes.CRelationClasses.
+      Check CRelationClasses.flip.
+      Fail Check flip.
 
-   A given library may be safe-required and later safe-required again (this is
-   a no-op), but a safe-loaded library cannot subsequently be loaded with a
-   plain :cmd:`Require`.
+   The intended use is processing untrusted compiled files: validate the
+   file with ``rocqchk`` (see :ref:`therocqcommands`), then load it with
+   ``Require (safe)``, which is designed to consume only data that
+   ``rocqchk`` checks.  This correspondence has not been fully audited; in
+   particular ``rocqchk`` does not validate compiled VM and native-compute
+   data, so avoid :tacn:`vm_compute` and :tacn:`native_compute` when
+   relying on untrusted files.
+
+   Safe-requiring an already safe-required library is a no-op;
+   safe-requiring an already fully loaded library uses the fully loaded
+   version.  The converse is not supported:
 
    .. exn:: Cannot unsafe-require library @qualid because it was previously required with (safe).
 
-      A plain :cmd:`Require` was used on a library that had already been loaded
-      with :cmd:`Require (safe)`.  Loading only the kernel content and then
-      replaying the full library object is not supported.
+      A plain :cmd:`Require` was used on a library previously loaded with
+      ``Require (safe)``, directly or as a dependency.
 
 .. cmd:: Print Libraries
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -175,6 +175,7 @@ DELETE: [
 | test_doublepipe_cumul_univ_decl
 | test_semicolon_cumul_univ_decl
 | test_univ_cst
+| test_unsafe_require
 ]
 
 (* additional nts to be spliced *)
@@ -765,6 +766,10 @@ gallina_ext: [
 | DELETE "Require" export_token LIST1 filtered_import
 | REPLACE "From" global "Require" export_token LIST1 filtered_import
 | WITH OPT [ "From" dirpath ] "Require" export_token LIST1 filtered_import
+
+| DELETE "Require" "(" "safe" ")" LIST1 qualid
+| REPLACE "From" global "Require" "(" "safe" ")" LIST1 qualid
+| WITH OPT [ "From" dirpath ] "Require" "(" "safe" ")" LIST1 qualid
 
 | REPLACE "From" global "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
 | WITH "From" dirpath "Extra" "Dependency" ne_string OPT [ "as" IDENT ]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1180,8 +1180,10 @@ gallina_ext: [
 | "End" identref
 | "Collection" identref ":=" section_subset_expr
 | "From" global "Extra" "Dependency" ne_string OPT [ "as" IDENT ]
-| "Require" export_token LIST1 filtered_import
-| "From" global "Require" export_token LIST1 filtered_import
+| "Require" "(" "safe" ")" LIST1 qualid
+| "From" global "Require" "(" "safe" ")" LIST1 qualid
+| "Require" test_unsafe_require export_token LIST1 filtered_import
+| "From" global "Require" test_unsafe_require export_token LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import
 | "Include" module_type_inl LIST0 ext_module_type

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -980,6 +980,7 @@ command: [
 | "End" ident
 | "Collection" ident ":=" section_var_expr
 | "From" dirpath "Extra" "Dependency" string OPT [ "as" ident ]
+| OPT [ "From" dirpath ] "Require" "(" "safe" ")" LIST1 qualid
 | OPT [ "From" dirpath ] "Require" OPT ( [ "Import" | "Export" ] OPT import_categories ) LIST1 filtered_import
 | "Import" OPT import_categories LIST1 filtered_import
 | "Export" OPT import_categories LIST1 filtered_import

--- a/test-suite/misc/coqdep-require-safe.sh
+++ b/test-suite/misc/coqdep-require-safe.sh
@@ -4,10 +4,7 @@ set -e
 
 cd misc/coqdep-require-safe
 
-code=0
-$coqdep -worker @ROCQWORKER@ -Q . 'Pfx' ./*.v > stdout 2> stderr || code=$?
+$coqdep -worker @ROCQWORKER@ -Q . Pfx Foo.v bare.v frombare.v fromsafe.v safe.v > stdout 2> stderr
 
 diff -u stdout.ref stdout
 diff -u stderr.ref stderr
-
-exit $code

--- a/test-suite/misc/coqdep-require-safe.sh
+++ b/test-suite/misc/coqdep-require-safe.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd misc/coqdep-require-safe
+
+code=0
+$coqdep -worker @ROCQWORKER@ -Q . 'Pfx' ./*.v > stdout 2> stderr || code=$?
+
+diff -u stdout.ref stdout
+diff -u stderr.ref stderr
+
+exit $code

--- a/test-suite/misc/coqdep-require-safe/.gitignore
+++ b/test-suite/misc/coqdep-require-safe/.gitignore
@@ -1,0 +1,2 @@
+/stderr
+/stdout

--- a/test-suite/misc/coqdep-require-safe/Foo.v
+++ b/test-suite/misc/coqdep-require-safe/Foo.v
@@ -1,0 +1,1 @@
+(* target library required by the other files *)

--- a/test-suite/misc/coqdep-require-safe/bare.v
+++ b/test-suite/misc/coqdep-require-safe/bare.v
@@ -1,0 +1,1 @@
+Require Pfx.Foo.

--- a/test-suite/misc/coqdep-require-safe/frombare.v
+++ b/test-suite/misc/coqdep-require-safe/frombare.v
@@ -1,0 +1,1 @@
+From Pfx Require Foo.

--- a/test-suite/misc/coqdep-require-safe/fromsafe.v
+++ b/test-suite/misc/coqdep-require-safe/fromsafe.v
@@ -1,0 +1,1 @@
+From Pfx Require (safe) Foo.

--- a/test-suite/misc/coqdep-require-safe/safe.v
+++ b/test-suite/misc/coqdep-require-safe/safe.v
@@ -1,0 +1,1 @@
+Require (safe) Pfx.Foo.

--- a/test-suite/misc/coqdep-require-safe/stdout.ref
+++ b/test-suite/misc/coqdep-require-safe/stdout.ref
@@ -1,0 +1,5 @@
+Foo.vo Foo.glob Foo.v.beautified Foo.required_vo: Foo.v @ROCQWORKER@
+bare.vo bare.glob bare.v.beautified bare.required_vo: bare.v Foo.vo @ROCQWORKER@
+frombare.vo frombare.glob frombare.v.beautified frombare.required_vo: frombare.v Foo.vo @ROCQWORKER@
+fromsafe.vo fromsafe.glob fromsafe.v.beautified fromsafe.required_vo: fromsafe.v Foo.vo @ROCQWORKER@
+safe.vo safe.glob safe.v.beautified safe.required_vo: safe.v Foo.vo @ROCQWORKER@

--- a/test-suite/output/SafeRequire.out
+++ b/test-suite/output/SafeRequire.out
@@ -12,7 +12,48 @@ fun (A B C : Type) (f : A -> B -> C) (x : B) (y : A) => f y x
      : forall A B C : Type, (A -> B -> C) -> B -> A -> C
 
 Arguments CRelationClasses.flip A B C f x y
-File "./output/SafeRequire.v", line 9, characters 0-27:
+CRelationClasses.flip
+     : forall A B C : Set, (A -> B -> C) -> B -> A -> C
+CRelationClasses.arrow
+     : Type -> Type -> Type
+CRelationClasses.arrow nat nat
+     : Type
+Closed under the global context
+File "./output/SafeRequire.v", line 24, characters 11-19:
+The command has indeed failed with message:
+The reference positive was not found in the current environment.
+BinNums.positive
+     : Set
+BinNums.xI : BinNums.positive -> BinNums.positive
+
+BinNums.xI is not universe polymorphic
+Expands to: Constructor Corelib.Numbers.BinNums.xI
+Inductive Corelib.Numbers.BinNums.positive
+  (shorter name to refer to it in current context is BinNums.positive)
+Constructor Corelib.Numbers.BinNums.xH
+  (shorter name to refer to it in current context is BinNums.xH)
+fun p : BinNums.positive =>
+match p with
+| BinNums.xI q | BinNums.xO q => q
+| BinNums.xH => BinNums.xH
+end
+     : BinNums.positive -> BinNums.positive
+PosDef.Pos.mask
+     : Set
+PosDef.Pos.IsPos : BinNums.positive -> PosDef.Pos.mask
+
+PosDef.Pos.IsPos is not universe polymorphic
+Expands to: Constructor Corelib.BinNums.PosDef.Pos.IsPos
+PosDef.Pos.succ
+     : BinNums.positive -> BinNums.positive
+Module Corelib.BinNums.PosDef.Pos
+  (shorter name to refer to it in current context is PosDef.Pos)
+Module PosDef.Pos
+Module Type Corelib.ssr.ssrunder.UNDER_REL
+  (shorter name to refer to it in current context is ssrunder.UNDER_REL)
+Module Corelib.ssr.ssrunder.Under_rel
+  (shorter name to refer to it in current context is ssrunder.Under_rel)
+File "./output/SafeRequire.v", line 58, characters 0-27:
 The command has indeed failed with message:
 Cannot unsafe-require library Corelib.Classes.CRelationClasses
 because it was previously required with (safe).

--- a/test-suite/output/SafeRequire.out
+++ b/test-suite/output/SafeRequire.out
@@ -19,7 +19,7 @@ CRelationClasses.arrow
 CRelationClasses.arrow nat nat
      : Type
 Closed under the global context
-File "./output/SafeRequire.v", line 24, characters 11-19:
+File "./output/SafeRequire.v", line 25, characters 11-19:
 The command has indeed failed with message:
 The reference positive was not found in the current environment.
 BinNums.positive
@@ -29,9 +29,7 @@ BinNums.xI : BinNums.positive -> BinNums.positive
 BinNums.xI is not universe polymorphic
 Expands to: Constructor Corelib.Numbers.BinNums.xI
 Inductive Corelib.Numbers.BinNums.positive
-  (shorter name to refer to it in current context is BinNums.positive)
 Constructor Corelib.Numbers.BinNums.xH
-  (shorter name to refer to it in current context is BinNums.xH)
 fun p : BinNums.positive =>
 match p with
 | BinNums.xI q | BinNums.xO q => q
@@ -53,7 +51,7 @@ Module Type Corelib.ssr.ssrunder.UNDER_REL
   (shorter name to refer to it in current context is ssrunder.UNDER_REL)
 Module Corelib.ssr.ssrunder.Under_rel
   (shorter name to refer to it in current context is ssrunder.Under_rel)
-File "./output/SafeRequire.v", line 58, characters 0-27:
+File "./output/SafeRequire.v", line 59, characters 0-27:
 The command has indeed failed with message:
 Cannot unsafe-require library Corelib.Classes.CRelationClasses
 because it was previously required with (safe).

--- a/test-suite/output/SafeRequire.v
+++ b/test-suite/output/SafeRequire.v
@@ -5,5 +5,54 @@ Type CRelationClasses.flip.
 About CRelationClasses.flip.
 Print CRelationClasses.flip.
 
+(* universe-polymorphic constant: instances can be given explicitly *)
+Check CRelationClasses.flip@{Set Set Set}.
+
+(* a monomorphic Type-former from the same library, showing its universe
+   constraints were imported (the application typechecks) *)
+Check CRelationClasses.arrow.
+Check (CRelationClasses.arrow nat nat).
+
+(* Print Assumptions on an opaque (Qed) proof exercises the lazy opaque table
+   under safe loading *)
+Print Assumptions CRelationClasses.complement_inverse.
+
+(* Inductive types and their constructors are available by fully-qualified
+   name; short names are not registered. *)
+Require (safe) Corelib.Numbers.BinNums.
+
+Fail Check positive.
+Check Corelib.Numbers.BinNums.positive.
+About Corelib.Numbers.BinNums.xI.
+Locate Corelib.Numbers.BinNums.positive.
+Locate Corelib.Numbers.BinNums.xH.
+
+(* pattern-matching / unification with a safe-required inductive typechecks *)
+Check (fun p : Corelib.Numbers.BinNums.positive =>
+         match p with
+         | Corelib.Numbers.BinNums.xI q => q
+         | Corelib.Numbers.BinNums.xO q => q
+         | Corelib.Numbers.BinNums.xH => Corelib.Numbers.BinNums.xH
+         end).
+
+(* Nested modules: PosDef contains an inner module [Pos] with its own
+   inductive [mask]. Constants and constructors resolve through the inner
+   module path, and the module itself can be located and printed even though
+   module names are only pushed at the Synterp stage. *)
+Require (safe) Corelib.BinNums.PosDef.
+
+Check Corelib.BinNums.PosDef.Pos.mask.
+About Corelib.BinNums.PosDef.Pos.IsPos.
+Check Corelib.BinNums.PosDef.Pos.succ.
+Locate Module Corelib.BinNums.PosDef.Pos.
+Print Module Type Corelib.BinNums.PosDef.Pos.
+
+(* Module types are resolved too. ssrunder declares a [Module Type UNDER_REL]
+   and a [Module Under_rel]. *)
+Require (safe) Corelib.ssr.ssrunder.
+
+Locate Corelib.ssr.ssrunder.UNDER_REL.
+Locate Module Corelib.ssr.ssrunder.Under_rel.
+
 (* could do a full require of safe-required deps instead but needs more work *)
 Fail Require SetoidTactics.

--- a/test-suite/output/SafeRequire.v
+++ b/test-suite/output/SafeRequire.v
@@ -8,8 +8,8 @@ Print CRelationClasses.flip.
 (* universe-polymorphic constant: instances can be given explicitly *)
 Check CRelationClasses.flip@{Set Set Set}.
 
-(* a monomorphic Type-former from the same library, showing its universe
-   constraints were imported (the application typechecks) *)
+(* a monomorphic Type-former from the same library, showing its universes
+   were imported (the application typechecks) *)
 Check CRelationClasses.arrow.
 Check (CRelationClasses.arrow nat nat).
 
@@ -17,22 +17,23 @@ Check (CRelationClasses.arrow nat nat).
    under safe loading *)
 Print Assumptions CRelationClasses.complement_inverse.
 
-(* Inductive types and their constructors are available by fully-qualified
-   name; short names are not registered. *)
+(* Inductive types and their constructors are available qualified by (at
+   least) the name of the file that defines them, as with plain Require;
+   bare short names are not available. *)
 Require (safe) Corelib.Numbers.BinNums.
 
 Fail Check positive.
-Check Corelib.Numbers.BinNums.positive.
-About Corelib.Numbers.BinNums.xI.
-Locate Corelib.Numbers.BinNums.positive.
-Locate Corelib.Numbers.BinNums.xH.
+Check BinNums.positive.
+About BinNums.xI.
+Locate BinNums.positive.
+Locate BinNums.xH.
 
 (* pattern-matching / unification with a safe-required inductive typechecks *)
-Check (fun p : Corelib.Numbers.BinNums.positive =>
+Check (fun p : BinNums.positive =>
          match p with
-         | Corelib.Numbers.BinNums.xI q => q
-         | Corelib.Numbers.BinNums.xO q => q
-         | Corelib.Numbers.BinNums.xH => Corelib.Numbers.BinNums.xH
+         | BinNums.xI q => q
+         | BinNums.xO q => q
+         | BinNums.xH => BinNums.xH
          end).
 
 (* Nested modules: PosDef contains an inner module [Pos] with its own

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -525,7 +525,6 @@ let cache_one_safe_require_interp m =
          effects but the kernel did not forget the library. *)
       ignore(Global.lookup_module mp);
     with Not_found ->
-      (* $2 $5 $4 *)
       let mp' = Global.import compiled m.library_vm m.library_digests in
       if not (ModPath.equal mp mp') then
         anomaly (Pp.str "Unexpected disk module name.")


### PR DESCRIPTION
Follow-ups for rocq-prover/rocq#22291, offered against your `safrequire` branch (base 71e295ba3c):

- remove a stray `(* $2 $5 $4 *)` copy-paste comment in `cache_one_safe_require_interp`
- changelog entry (08-vernac-commands-and-options)
- refman: `Require ( safe )` documented next to `Require`, **plus docgram regeneration** — `make doc_gram_verify` fails on the branch as-is since `g_vernac.mlg` changed (new `common.edit_mlg` rules mirror the existing Require edits)
- the rocqdep test you mentioned: `misc/coqdep-require-safe.sh` shows `Require`, `From … Require`, and both `(safe)` forms produce identical dep edges
- broader output-test coverage: inductives/constructors, nested modules (resolution through inner module paths, `Locate Module`, `Print Module Type`), modtypes, universe instances + monomorphic constraints, and `Print Assumptions` on a safe-required opaque (lazy opaque table works)

All green locally: `make world`, `doc_gram_verify`, the base SafeRequire test, and the new tests.

Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
