### PR TITLE
Require (safe): support Import/Export

### DIFF
--- a/test-suite/output/SafeRequireImport.out
+++ b/test-suite/output/SafeRequireImport.out
@@ -1,0 +1,17 @@
+File "./output/SafeRequireImport.v", line 7, characters 11-15:
+The command has indeed failed with message:
+The reference flip was not found in the current environment.
+CRelationClasses.flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+respectful
+     : forall A B : Type, crelation A -> crelation B -> crelation (A -> B)
+arrow
+     : Type -> Type -> Type
+unary_operation
+     : Type -> Type
+File "./output/SafeRequireImport.v", line 30, characters 0-30:
+The command has indeed failed with message:
+Cannot unsafe-require library Corelib.Classes.CRelationClasses
+because it was previously required with (safe).

--- a/test-suite/output/SafeRequireImport.v
+++ b/test-suite/output/SafeRequireImport.v
@@ -1,0 +1,30 @@
+(* Test Import/Export support for Require (safe).
+   See also output/SafeRequire.v for the plain (no-import) behaviour. *)
+
+(* 1. Plain Require (safe): only fully-qualified names are visible.
+   The short name [flip] does not resolve, the qualified one does. *)
+Require (safe) CRelationClasses.
+Fail Check flip.
+Check CRelationClasses.flip.
+
+(* 2. A standalone Import on the already safe-loaded library pushes the
+   short names (this exercises the safe branch of Declaremods' import
+   machinery, since the library has no ModObjs entry). *)
+Import CRelationClasses.
+Check flip.
+
+(* 3. Require (safe) Import: the short name is available immediately. *)
+Require (safe) Import CMorphisms.
+Check respectful.
+
+(* 4. Require (safe) Export: like Import for the current session, and
+   records the standard ExportObject for re-export downstream. *)
+Require (safe) Export CRelationClasses.
+Check arrow.
+
+(* 5. The From ... Require (safe) Import form also parses and imports. *)
+From Corelib Require (safe) Import RelationClasses.
+Check unary_operation.
+
+(* A plain Require of a safe-imported library still errors. *)
+Fail Require CRelationClasses.

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -226,6 +226,7 @@ module type StagedModS = sig
   val load_keep : int -> full_path -> ModPath.t -> keep_objects -> unit
   val load_escape : int -> full_path -> ModPath.t -> escape_objects -> unit
   val load_module : int -> full_path -> ModPath.t -> substitutive_objects -> unit
+  val load_safe_library : DirPath.t -> Mod_declarations.module_body -> unit
   val import_modules : export:Lib.export_flag -> (open_filter * ModPath.t) list -> unit
 
   val add_leaf : Libobject.t -> unit
@@ -436,6 +437,115 @@ module ModObjs :
    let all () = !table
  end
 
+(** {6 SafeLibs : the set of libraries loaded through [Require (safe)]}
+
+   A [Require (safe)] library is imported in the kernel but no libobject
+   replay is performed, so it has no entry in [ModObjs] and cannot be
+   imported through the usual object-collection machinery. We record the
+   set of such libraries (per stage) so that [Import]/[Export] of a
+   safe-loaded library can push names directly by walking the kernel
+   module structure instead. *)
+
+module SafeLibs :
+ sig
+   val register : DirPath.t -> Mod_declarations.module_body -> unit
+   val find : DirPath.t -> Mod_declarations.module_body option
+ end =
+ struct
+   let table =
+     Summary.ref ~stage:Actions.stage (DirPath.Map.empty : Mod_declarations.module_body DirPath.Map.t)
+       ~name:(Actions.modobjs_table_name ^ "-SAFE-LIBS")
+   let register dp mb = (table := DirPath.Map.add dp mb !table)
+   let find dp = DirPath.Map.find_opt dp !table
+ end
+
+(** {6 Name pushing for [Require (safe)] libraries}
+
+   These walk the kernel module structure of a safe-loaded library and
+   push short names into the nametab. The walk carries the module-nesting
+   depth [i] (the library module is depth 1); an object directly inside a
+   module at depth [i] has [i] path components stripped from its full name,
+   hence a "[Until]-index" of [i+1].
+
+   The visibility to push at is computed by [vis] from that [Until]-index:
+   - at load time, [Until k], so only fully-qualified(-ish) names are
+     visible (as a plain [Require (safe)] should);
+   - at import time, [Exactly (k-1)], matching the depth [open_object]
+     would use for the same object during a normal [Import] (a top-level
+     constant of the library becomes visible under its bare name). The top
+     library module name itself ([Until]-index 1) is not (re-)pushed on
+     import, mirroring normal library import which never re-pushes it.
+
+   Constants/inductives/constructors exist only at the [Interp] stage;
+   module and module type short names at [Synterp]. *)
+
+let safe_require_mind_names vis sp mind mib =
+  mib.Declarations.mind_packets |> Array.iteri @@ fun ind (mip:Declarations.one_inductive_body) ->
+  let ind = (mind, ind) in
+  let () = Option.iter (fun vis -> Nametab.push vis (Libnames.add_path_suffix sp mip.mind_typename) (GlobRef.IndRef ind)) vis in
+  mip.mind_consnames |> Array.iteri @@ fun ctor cna ->
+  Option.iter (fun vis -> Nametab.push vis (Libnames.add_path_suffix sp cna) (GlobRef.ConstructRef (ind, ctor+1))) vis
+
+let rec safe_require_mod_names ~vis i sp mp mb =
+  let () = match Actions.stage with
+    | Summary.Stage.Synterp -> Option.iter (fun v -> Nametab.push_module v sp mp) (vis i)
+    | Interp -> ()
+  in
+  match Mod_declarations.mod_type mb with
+  | MoreFunctor _ -> ()
+  | NoFunctor contents ->
+    contents |> List.iter @@ fun (lab, contents) ->
+    match contents with
+    | Declarations.SFBrules _ ->
+      ()
+    | SFBconst _ ->
+      begin match Actions.stage with
+      | Synterp -> ()
+      | Interp ->
+        let kn = Global.constant_of_delta_kn (KerName.make mp lab) in
+        let sp = Libnames.add_path_suffix sp lab in
+        Option.iter (fun v -> Nametab.push v sp (GlobRef.ConstRef kn)) (vis (i+1))
+      end
+    | SFBmind mib ->
+      begin match Actions.stage with
+      | Synterp -> ()
+      | Interp ->
+        let mind = Global.mind_of_delta_kn (KerName.make mp lab) in
+        safe_require_mind_names (vis (i+1)) sp mind mib
+      end
+    | SFBmodtype _ ->
+      begin match Actions.stage with
+      | Synterp ->
+        let mp = ModPath.MPdot (mp, lab) in
+        let sp = Libnames.add_path_suffix sp lab in
+        Option.iter (fun v -> Nametab.push_modtype v sp mp) (vis (i+1))
+      | Interp -> ()
+      end
+    | SFBmodule mb ->
+      safe_require_mod_names ~vis (i+1) (Libnames.add_path_suffix sp lab) (MPdot (mp,lab)) mb
+
+let safe_require_names ~vis dp mb =
+  let mp = ModPath.MPfile dp in
+  let sp = Libnames.make_path0 dp in
+  safe_require_mod_names ~vis 1 sp mp mb
+
+(** Push the fully-qualified-only ([Until]) names of a safe-loaded library
+    and record it as safe-loaded (so a later [Import]/[Export] can find its
+    module structure). [mb] is the kernel module body of the library, which
+    at the [Synterp] stage cannot be recovered from the kernel (it is not
+    imported there) and so is supplied by the caller. *)
+let load_safe_library dp mb =
+  safe_require_names ~vis:(fun k -> Some (Nametab.Until k)) dp mb;
+  SafeLibs.register dp mb
+
+(** Push the short ([Exactly]) names of a safe-loaded library, as done by
+    [Import]. Known divergence from a real [Import]: the kernel structure
+    carries no vernacular locality info ([ImportNeedQualified] from a
+    [Local Definition] lives only in libobjects), so this may expose short
+    names that a real [Import] would keep qualified-only. *)
+let import_safe_library dp mb =
+  safe_require_names ~vis:(fun k -> if k <= 1 then None else Some (Nametab.Exactly (k-1))) dp mb
+
  open Expand
 
 (** {6 Declaration of module substitutive objects} *)
@@ -535,6 +645,13 @@ let mark_object f obj (exports,acc) =
   (exports, (f,obj)::acc)
 
 let rec collect_module (f,mp) acc =
+  (* A [Require (safe)] library has no [ModObjs] entry; importing it pushes
+     short names directly by walking the kernel structure. This must take
+     precedence over the (missing) [ModObjs] lookup. Filters are ignored:
+     there are no libobjects/categories to filter on. *)
+  match (match mp with MPfile dp -> Option.map (fun mb -> (dp, mb)) (SafeLibs.find dp) | _ -> None) with
+  | Some (dp, mb) -> import_safe_library dp mb; acc
+  | None ->
   try
     (* May raise Not_found for unknown module and for functors *)
     let modobjs = ModObjs.get mp in
@@ -1557,6 +1674,9 @@ let register_library dir (objs:library_objects) =
   SynterpVisitor.load_escape 2 sp mp escapeobjs;
   SynterpVisitor.load_keep 2 sp mp keepobjs
 
+let register_safe_library dir mb =
+  SynterpVisitor.load_safe_library dir mb
+
 let import_modules = SynterpVisitor.import_modules
 
 let import_module f ~export mp =
@@ -1648,6 +1768,9 @@ let register_library dir cenv (objs:library_objects) digest vmtab =
   InterpVisitor.load_module 1 sp mp ([],Objs sobjs);
   InterpVisitor.load_escape 1 sp mp escapeobjs;
   InterpVisitor.load_keep 1 sp mp keepobjs
+
+let register_safe_library dir mb =
+  InterpVisitor.load_safe_library dir mb
 
 let import_modules = InterpVisitor.import_modules
 

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -84,6 +84,11 @@ val import_modules : export:Lib.export_flag -> (Libobject.open_filter * ModPath.
 
 val register_library : library_name -> library_objects -> unit
 
+(** Register a [Require (safe)] library: push its fully-qualified-only
+    names by walking the kernel module structure (no libobject replay) and
+    record it as safe-loaded so a later [Import]/[Export] can find it. *)
+val register_safe_library : library_name -> Mod_declarations.module_body -> unit
+
 val close_section : unit -> unit
 
 end
@@ -136,6 +141,12 @@ val register_library :
   Safe_typing.compiled_library -> library_objects -> Safe_typing.vodigest ->
   Vmlibrary.on_disk ->
   unit
+
+(** Register a [Require (safe)] library: push its fully-qualified-only
+    names by walking the kernel module structure (no libobject replay) and
+    record it as safe-loaded so a later [Import]/[Export] can find it. The
+    caller must have already imported the library into the kernel. *)
+val register_safe_library : library_name -> Mod_declarations.module_body -> unit
 
 (** [import_module export mp] imports the module [mp].
    It modifies Nametab and performs the [open_object] function for

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -741,11 +741,12 @@ GRAMMAR EXTEND Gram
           { VernacSynterp (VernacExtraDependency (ns, f, Option.map Id.of_string id)) }
 
       (* Requiring an already compiled module *)
-      | IDENT "Require"; "("; IDENT "safe"; ")"; qidl = LIST1 qualid ->
-          { VernacSynterp (VernacSafeRequire (None, qidl)) }
-      | IDENT "From" ; ns = global ; IDENT "Require"; "("; IDENT "safe"; ")";
+      | IDENT "Require"; "("; IDENT "safe"; ")"; export = safe_export_token;
         qidl = LIST1 qualid ->
-        { VernacSynterp (VernacSafeRequire (Some ns, qidl)) }
+          { VernacSynterp (VernacSafeRequire (None, export, qidl)) }
+      | IDENT "From" ; ns = global ; IDENT "Require"; "("; IDENT "safe"; ")";
+        export = safe_export_token; qidl = LIST1 qualid ->
+        { VernacSynterp (VernacSafeRequire (Some ns, export, qidl)) }
 
       (* Requiring an already compiled module *)
       | IDENT "Require"; test_unsafe_require; export = export_token; qidl = LIST1 filtered_import ->
@@ -780,6 +781,11 @@ GRAMMAR EXTEND Gram
   export_token:
     [ [ IDENT "Import"; cats = OPT import_categories -> { Some (Import,cats) }
       | IDENT "Export"; cats = OPT import_categories -> { Some (Export,cats) }
+      |  -> { None } ] ]
+  ;
+  safe_export_token:
+    [ [ IDENT "Import" -> { Some Import }
+      | IDENT "Export" -> { Some Export }
       |  -> { None } ] ]
   ;
   ext_module_type:

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -458,60 +458,12 @@ let require_library_syntax_from_dirpath ~intern modrefl =
   Lib.add_leaf (in_require_syntax needed);
   List.map snd needed
 
-(* safe require *)
-
-let safe_require_mind_names vis sp mind mib =
-  mib.Declarations.mind_packets |> Array.iteri @@ fun ind (mip:Declarations.one_inductive_body) ->
-  let ind = (mind, ind) in
-  let () = Nametab.push vis (Libnames.add_path_suffix sp mip.mind_typename) (IndRef ind) in
-  mip.mind_consnames |> Array.iteri @@ fun ctor cna ->
-  Nametab.push vis (Libnames.add_path_suffix sp cna) (ConstructRef (ind, ctor+1))
-
-let rec safe_require_mod_names ~stage i sp mp mb =
-  let () = match stage with
-    | Summary.Stage.Synterp -> Nametab.push_module (Until i) sp mp
-    | Interp -> ()
-  in
-  match Mod_declarations.mod_type mb with
-  | MoreFunctor _ -> ()
-  | NoFunctor contents ->
-    contents |> List.iter @@ fun (lab, contents) ->
-    match contents with
-    | Declarations.SFBrules _ ->
-      ()
-    | SFBconst _ ->
-      begin match stage with
-      | Synterp -> ()
-      | Interp ->
-        let kn = Global.constant_of_delta_kn (KerName.make mp lab) in
-        let sp = Libnames.add_path_suffix sp lab in
-        Nametab.push (Until (i+1)) sp (ConstRef kn)
-      end
-    | SFBmind mib ->
-      begin match stage with
-      | Synterp -> ()
-      | Interp ->
-        let mind = Global.mind_of_delta_kn (KerName.make mp lab) in
-        safe_require_mind_names (Until (i+1)) sp mind mib
-      end
-    | SFBmodtype _ ->
-      begin match stage with
-      | Synterp ->
-        let mp = ModPath.MPdot (mp, lab) in
-        let sp = Libnames.add_path_suffix sp lab in
-        Nametab.push_modtype (Until (i+1)) sp mp
-      | Interp -> ()
-      end
-    | SFBmodule mb ->
-      safe_require_mod_names ~stage (i+1) (Libnames.add_path_suffix sp lab) (MPdot (mp,lab)) mb
-
-let safe_require_names ~stage dp mb =
-  let mp = ModPath.MPfile dp in
-  let sp = Libnames.make_path0 dp in
-  safe_require_mod_names ~stage 1 sp mp mb
+(* safe require: the kernel-side import and the name-pushing walk live in
+   declaremods.ml (see [Declaremods.*.register_safe_library]); here we only
+   drive them and maintain library.ml's bookkeeping tables. *)
 
 let cache_one_safe_require_synterp (root, m) =
-  safe_require_names ~stage:Synterp m.library_name
+  Declaremods.Synterp.register_safe_library m.library_name
     (Safe_typing.module_of_library m.library_data.md_compiled);
   register_loaded_library ~root SafeLoaded m
 
@@ -525,12 +477,11 @@ let cache_one_safe_require_interp m =
          effects but the kernel did not forget the library. *)
       ignore(Global.lookup_module mp);
     with Not_found ->
-      (* $2 $5 $4 *)
       let mp' = Global.import compiled m.library_vm m.library_digests in
       if not (ModPath.equal mp mp') then
         anomaly (Pp.str "Unexpected disk module name.")
   in
-  safe_require_names ~stage:Interp m.library_name
+  Declaremods.Interp.register_safe_library m.library_name
     (Safe_typing.module_of_library compiled);
   register_native_library m.library_name
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1393,14 +1393,19 @@ let pr_synterp_vernac_expr v =
     return (
       keyword "Declare Custom Entry " ++ Id.print s
     )
-  | VernacSafeRequire (from, l) ->
+  | VernacSafeRequire (from, exp, l) ->
     let from = match from with
       | None -> mt ()
       | Some r -> keyword "From" ++ spc () ++ pr_module r ++ spc ()
     in
+    let exp = match exp with
+      | None -> mt ()
+      | Some export -> pr_export_flag export ++ spc ()
+    in
     return (
       hov 2
-        (from ++ keyword "Require" ++ str "(safe)" ++ spc() ++ prlist_with_sep sep pr_qualid l)
+        (from ++ keyword "Require" ++ str "(safe)" ++ spc() ++ exp ++
+         prlist_with_sep sep pr_qualid l)
     )
   | VernacRequire (from, exp, l) ->
     let from = match from with

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -55,7 +55,7 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of lident
   | EVernacEndSegment of lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * qualid list
+  | EVernacSafeRequire of Library.library_t list * DirPath.t list * export_flag option * qualid list
   | EVernacRequire of
       Library.library_t list * DirPath.t list * export_with_cats option * (qualid * import_filter_expr) list
   | EVernacImport of (export_flag *
@@ -314,10 +314,18 @@ let require_locate from qidl =
       | Error LibNotFound -> Loc.raise ?loc:qid.loc (NotFoundLibrary (root, qid)))
     qidl
 
-let synterp_safe_require ~intern from qidl =
+let synterp_safe_require ~intern from export qidl =
   let modrefl = require_locate from qidl in
   Coq_config.gc_ramp_up @@ fun () ->
   let needed = Library.safe_require_synterp ~intern modrefl in
+  (* Import/Export goes through the standard [import_module] path: our
+     hook in Declaremods pushes the short names of a safe-loaded library,
+     and [Export] records the usual [ExportObject] for re-export. *)
+  Option.iter (fun export ->
+      List.iter (fun (_, m) ->
+          Declaremods.Synterp.import_module Libobject.unfiltered ~export (MPfile m))
+        modrefl)
+    export;
   needed, List.map snd modrefl
 
 let synterp_require ~intern from export qidl =
@@ -420,9 +428,9 @@ let rec synterp ~intern ?loc ~atts v =
     | VernacEndSegment lid ->
       synterp_end_segment lid;
       EVernacEndSegment lid
-    | VernacSafeRequire (from, qidl) ->
-      let needed, modrefl = synterp_safe_require ~intern from qidl in
-      EVernacSafeRequire (needed, modrefl, qidl)
+    | VernacSafeRequire (from, export, qidl) ->
+      let needed, modrefl = synterp_safe_require ~intern from export qidl in
+      EVernacSafeRequire (needed, modrefl, export, qidl)
     | VernacRequire (from, export, qidl) ->
       let needed, modrefl = synterp_require ~intern from export qidl in
       EVernacRequire (needed, modrefl, export, qidl)

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -32,7 +32,7 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of Names.lident
   | EVernacEndSegment of Names.lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * qualid list
+  | EVernacSafeRequire of Library.library_t list * DirPath.t list * Vernacexpr.export_flag option * qualid list
   | EVernacRequire of
       Library.library_t list * DirPath.t list * Vernacexpr.export_with_cats option * (qualid * Vernacexpr.import_filter_expr) list
   | EVernacImport of (Vernacexpr.export_flag * Libobject.open_filter) *

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1667,12 +1667,20 @@ let warn_require_in_section =
     (fun () -> strbrk "Use of “Require” inside a section is fragile." ++ spc() ++
                strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
-let vernac_safe_require_interp needed modrefl qidl =
-if Lib.sections_are_opened () then warn_require_in_section ();
+let vernac_safe_require_interp needed modrefl export qidl =
+  if Lib.sections_are_opened () then warn_require_in_section ();
   if Dumpglob.dump () then
     List.iter2 (fun {CAst.loc} dp -> Dumpglob.dump_libref ?loc dp "lib") qidl modrefl;
   Coq_config.gc_ramp_up @@ fun () ->
-  Library.safe_require_interp needed
+  (* Load (kernel import + fully-qualified names, no libobject replay) *)
+  Library.safe_require_interp needed;
+  (* Import/Export: goes through the standard [import_module] path, which
+     our Declaremods hook redirects to the safe short-name walk. *)
+  Option.iter (fun export ->
+      List.iter (fun m ->
+          import_module_with_filter ~export Libobject.unfiltered (MPfile m) ImportAll)
+        modrefl)
+    export
 
 let vernac_require_interp needed modrefl export qidl =
   if Lib.sections_are_opened () then warn_require_in_section ();
@@ -2718,10 +2726,10 @@ let translate_vernac_synterp ?loc ~atts v = let open Vernactypes in match v with
     unsupported_attributes atts;
     vernac_end_segment lid
 
-  | EVernacSafeRequire (needed, modrefl, qidl) ->
+  | EVernacSafeRequire (needed, modrefl, export, qidl) ->
     vtdefault (fun () ->
         unsupported_attributes atts;
-        vernac_safe_require_interp needed modrefl qidl)
+        vernac_safe_require_interp needed modrefl export qidl)
 
   | EVernacRequire (needed, modrefl, export, qidl) ->
     vtdefault(fun () ->

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -377,7 +377,7 @@ type synterp_vernac_expr =
   | VernacDeclareCustomEntry of Id.t
   | VernacBeginSection of lident
   | VernacEndSegment of lident
-  | VernacSafeRequire of qualid option * qualid list
+  | VernacSafeRequire of qualid option * export_flag option * qualid list
   | VernacRequire of
       qualid option * export_with_cats option * (qualid * import_filter_expr) list
   | VernacImport of export_with_cats * (qualid * import_filter_expr) list


### PR DESCRIPTION
Follow-up for rocq-prover/rocq#22291, offered against your `safrequire` branch (base 71e295ba3c): `Require (safe) Import`/`Require (safe) Export` (incl. `From` forms), and standalone `Import`/`Export` of safe-required libraries.

Mechanism: the name-pushing walk moves from library.ml into declaremods.ml with a per-stage `SafeLibs` registry (dirpath → module body; the body can't be recovered from the kernel at Synterp). The import machinery's `collect_module` checks the registry before the ModObjs lookup and runs an `Exactly`-visibility walk instead of object replay — one hook covers standalone Import/Export, the Require flags, and downstream `ExportObject` replay. Export records the standard `ExportObject` via `import_module ~export`; no new object type. (Import visibility needs `Exactly (k-1)` to match `open_object`'s depth.)

Known semantic divergence, commented in code: locality (`ImportNeedQualified`) lives only in libobjects, so a safe Import can expose short names a real Import keeps qualified.

Tests: output/SafeRequireImport.v covers FQN-only before import, standalone `Import` on a safe-loaded lib, both Require flags, the `From` form, and the SafeLoaded guard still erroring. `make world`, the modules test group, and module-related output tests all pass.

Note: conflicts with the dep-propagation offer (both restructure the safe-registration path); a combined PR reconciling them is offered separately.

Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
