### PR TITLE
Require (safe): persist safe-ness of dependencies into the .vo

### DIFF
--- a/checker/checkLibrary.ml
+++ b/checker/checkLibrary.ml
@@ -285,6 +285,7 @@ type summary_disk = {
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
   md_info : library_info;
+  md_safe_deps : DirPath.Set.t;
 }
 
 type library_objects

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -613,7 +613,7 @@ let v_compiled_lib =
 (** Toplevel structures in a vo (see Cic.mli) *)
 
 let v_libsum =
-  v_tuple_c ("summary", [|v_dp;v_deps;v_string;v_any|])
+  v_tuple_c ("summary", [|v_dp;v_deps;v_string;v_any;v_set v_dp|])
 
 let v_lib =
   v_tuple_c ("library",[|v_compiled_lib;v_any;v_any|])

--- a/doc/changelog/08-vernac-commands-and-options/22291-safe-require-propagation.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22291-safe-require-propagation.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  A library compiled with :cmd:`Require` :n:`(safe)` now keeps those safe
+  dependencies safe for its downstream users: a plain :cmd:`Require` of such a
+  library loads it fully but only safe-loads the dependencies it had itself
+  safe-required (and, transitively, their dependencies). The set of
+  safe-required direct dependencies is recorded in each ``.vo`` file
+  (`#22291 <https://github.com/rocq-prover/rocq/pull/22291>`_,
+  by Gaëtan Gilbert and Jason Gross).

--- a/test-suite/misc/safe-require-propagation.sh
+++ b/test-suite/misc/safe-require-propagation.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# A library compiled with [Require (safe) M] keeps M (and M's dependencies)
+# safe for its downstream users: requiring such a library fully loads it but
+# only safe-loads its safe dependencies.
+
+set -e
+
+export PATH=$BIN:$PATH
+
+cd misc/safe-require-propagation
+rm -rf _test
+mkdir _test
+cp A.v B.v C.v B.out C.out _test
+cd _test
+
+# A safe-requires CMorphisms (which depends on CRelationClasses).
+rocq c -R . Top A.v
+
+# Requiring A fully must keep CRelationClasses safe (no implicit arguments,
+# and a plain require of it is still rejected).
+rocq c -test-mode -R . Top B.v > B.real 2>&1
+diff -u --strip-trailing-cr B.out B.real
+
+# Control: fully requiring CRelationClasses first, then A, works and keeps
+# CRelationClasses fully loaded.
+rocq c -test-mode -R . Top C.v > C.real 2>&1
+diff -u --strip-trailing-cr C.out C.real

--- a/test-suite/misc/safe-require-propagation/A.v
+++ b/test-suite/misc/safe-require-propagation/A.v
@@ -1,0 +1,1 @@
+Require (safe) Corelib.Classes.CMorphisms. (* depends on CRelationClasses *)

--- a/test-suite/misc/safe-require-propagation/B.out
+++ b/test-suite/misc/safe-require-propagation/B.out
@@ -1,0 +1,13 @@
+CRelationClasses.flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+CRelationClasses.flip@{u u0 u1} :
+forall A B C : Type, (A -> B -> C) -> B -> A -> C
+
+CRelationClasses.flip is universe polymorphic
+Arguments CRelationClasses.flip A B C f x y
+CRelationClasses.flip is transparent
+Expands to: Constant Corelib.Classes.CRelationClasses.flip
+File "./B.v", line 11, characters 0-46:
+The command has indeed failed with message:
+Cannot unsafe-require library Corelib.Classes.CRelationClasses
+because it was previously required with (safe).

--- a/test-suite/misc/safe-require-propagation/B.v
+++ b/test-suite/misc/safe-require-propagation/B.v
@@ -1,0 +1,11 @@
+(* A was compiled with [Require (safe) CMorphisms]: requiring A fully must
+   still keep CRelationClasses (a safe dependency, reached only through the
+   safe-required CMorphisms) safe. *)
+Require A.
+
+(* no implicit arguments, but can be used *)
+Type Corelib.Classes.CRelationClasses.flip.
+About Corelib.Classes.CRelationClasses.flip.
+
+(* a plain require of a propagated-safe library is still rejected *)
+Fail Require Corelib.Classes.CRelationClasses.

--- a/test-suite/misc/safe-require-propagation/C.out
+++ b/test-suite/misc/safe-require-propagation/C.out
@@ -1,0 +1,9 @@
+CRelationClasses.flip@{u u0 u1} :
+forall {A B C : Type}, (A -> B -> C) -> B -> A -> C
+
+CRelationClasses.flip is universe polymorphic
+Arguments CRelationClasses.flip {A B C}%_type_scope f%_function_scope x y
+CRelationClasses.flip is transparent
+Expands to: Constant Corelib.Classes.CRelationClasses.flip
+Declared in
+library Corelib.Classes.CRelationClasses, line 32, characters 11-15

--- a/test-suite/misc/safe-require-propagation/C.v
+++ b/test-suite/misc/safe-require-propagation/C.v
@@ -1,0 +1,5 @@
+(* Control: fully requiring CRelationClasses before A makes it fully loaded;
+   requiring A then reuses the full library silently. *)
+Require Corelib.Classes.CRelationClasses.
+Require A.
+About Corelib.Classes.CRelationClasses.flip.

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -91,6 +91,10 @@ type summary_disk = {
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
   md_info : Library_info.t;
+  (* Subset of the direct dependencies (i.e. of the dirpaths appearing in
+     [md_deps]) that were only safe-required (SafeLoaded) when this library
+     was compiled. Downstream requires must keep these dependencies safe. *)
+  md_safe_deps : DirPath.Set.t;
 }
 
 (*s Modules loaded in memory contain the following informations. They are
@@ -100,6 +104,7 @@ type library_t = {
   library_name : compilation_unit_name;
   library_data : library_disk;
   library_deps : (compilation_unit_name * Safe_typing.vodigest) array;
+  library_safe_deps : DirPath.Set.t;
   library_digests : Safe_typing.vodigest;
   library_info : Library_info.t;
   library_vm : Vmlibrary.on_disk;
@@ -238,6 +243,7 @@ let mk_library sd md digests vm =
     library_name     = sd.md_name;
     library_data     = md;
     library_deps     = sd.md_deps;
+    library_safe_deps = sd.md_safe_deps;
     library_digests  = digests;
     library_info     = sd.md_info;
     library_vm = vm;
@@ -303,44 +309,43 @@ let () = CErrors.register_handler (function
 let error_in_intern provenance dir (exn, info) =
   Exninfo.iraise (InternError { exn; provenance; dir }, info)
 
-(* Returns the digest of a library, checks both caches to see what is loaded *)
-let rec intern_library ~safe ~root ~intern (needed, contents as acc) dir =
-  (* Look if in the current logical environment *)
+(* Intern a library and its dependency closure.
+
+   Unlike a plain load, safe-ness is not decided during interning: we
+   first intern the whole closure (skipping already-loaded libraries,
+   whose dependencies are already loaded), and only afterwards compute a
+   per-library effective mode (see [compute_modes]) from the recorded
+   safe-dependency edges. This keeps a safe dependency of a fully-loaded
+   library safe for the current session too. *)
+let rec intern_library ~intern (needed, contents as acc) dir =
+  (* Look if in the current logical environment: already-loaded libraries
+     (whether full or safe) are terminal, their deps are already loaded. *)
   match find_library dir with
-  | Some (load_status, loaded_lib) ->
-    begin match safe, load_status with
-    | _, FullLoaded | true, _ -> loaded_lib, acc
-    | false, SafeLoaded ->
-      (* we could do a full require of this library and any SafeLoaded deps
-         but would need to make name pushing idempotent (otherwise it will error "foo already exists")
-         or somehow separate it from libobjects so that we can do nonlogical require without re-pushing names *)
-      CErrors.user_err
-        Pp.(str "Cannot unsafe-require library " ++ DirPath.print dir ++ spc() ++
-            str "because it was previously required with (safe).")
-    end
+  | Some _ -> acc
   | None ->
     (* Look if already listed in the accumulator *)
     match DirPath.Map.find_opt dir contents with
-    | Some interned_lib ->
-      interned_lib, acc
+    | Some _ ->
+      acc
     | None ->
       (* We intern the library, and then intern the deps *)
       match intern dir with
       | Ok m, provenance ->
         check_library_expected_name ~provenance dir m.library_name;
-        m, intern_library_deps ~safe ~root ~intern acc dir m
+        intern_library_deps ~intern acc dir m
       | Error iexn, provenance ->
         error_in_intern provenance dir iexn
 
-and intern_library_deps ~safe ~root ~intern libs dir m =
+and intern_library_deps ~intern (needed, contents) dir m =
+  let contents = DirPath.Map.add dir m contents in
   let needed, contents =
-    Array.fold_left (intern_mandatory_library ~safe ~intern dir)
-      libs m.library_deps in
-  ((root, dir) :: needed, DirPath.Map.add dir m contents )
+    Array.fold_left (intern_mandatory_library ~intern dir)
+      (needed, contents) m.library_deps in
+  ((false, dir) :: needed, contents)
 
-and intern_mandatory_library ~safe ~intern caller libs (dir,d) =
-  let m, libs = intern_library ~safe ~root:false ~intern libs dir in
-  let digest = m.library_digests in
+and intern_mandatory_library ~intern caller (needed, contents) (dir,d) =
+  let needed, contents = intern_library ~intern (needed, contents) dir in
+  let digest = digest_of_dep ~contents dir in
   let () = if not (Safe_typing.digest_match ~actual:digest ~required:d) then
     let from = library_full_filename caller in
     user_err
@@ -349,12 +354,112 @@ and intern_mandatory_library ~safe ~intern caller libs (dir,d) =
        str ") makes inconsistent assumptions over library " ++
        DirPath.print dir)
   in
-  libs
+  (needed, contents)
 
-let rec_intern_library ~safe ~intern libs (loc, dir) =
-  let m, libs = intern_library ~safe ~root:true ~intern libs dir in
-  Library_info.warn_library_info m.library_name m.library_info;
-  libs
+and digest_of_dep ~contents dir =
+  match DirPath.Map.find_opt dir contents with
+  | Some m -> m.library_digests
+  | None ->
+    match find_library dir with
+    | Some (_, m) -> m.library_digests
+    | None ->
+      anomaly Pp.(str "Missing library " ++ DirPath.print dir ++
+                  str " while interning dependencies.")
+
+let rec_intern_library ~intern (needed, contents) (_loc, dir) =
+  intern_library ~intern (needed, contents) dir
+
+(* [needed] is built dependencies-first (each dir is prepended after its
+   deps). A dir added as a dependency and then reached again as a root keeps
+   its original (earlier) position; mark such positions as roots. *)
+let promote_roots needed roots =
+  let roots = List.fold_left (fun s d -> DirPath.Set.add d s) DirPath.Set.empty roots in
+  List.map (fun (root, d) -> (root || DirPath.Set.mem d roots), d) needed
+
+(* Effective load mode computed for each library of an interned closure. *)
+type require_mode = ModeFull | ModeSafe
+
+(* Compute, for each newly-interned library of the closure, whether it must
+   be fully loaded or may be safe-loaded.
+
+   Roots get the command mode ([ModeFull] for [Require], [ModeSafe] for
+   [Require (safe)]). An edge A -> D is "safe" iff D belongs to A's recorded
+   safe dependencies ([library_safe_deps]), otherwise "normal". A library is
+   [ModeFull] iff it is reachable from a [ModeFull] root through a chain of
+   normal edges; otherwise it is [ModeSafe].
+
+   Fullness only grows, so this is a monotone fixpoint reached by a worklist
+   seeded with the full roots and propagated along normal edges. *)
+let compute_modes ~cmd_safe ~roots contents =
+  let full = ref DirPath.Set.empty in
+  let queue = Queue.create () in
+  let mark dir =
+    if DirPath.Map.mem dir contents && not (DirPath.Set.mem dir !full) then begin
+      full := DirPath.Set.add dir !full;
+      Queue.add dir queue
+    end
+  in
+  if not cmd_safe then List.iter mark roots;
+  while not (Queue.is_empty queue) do
+    let dir = Queue.pop queue in
+    let m = DirPath.Map.find dir contents in
+    Array.iter (fun (d, _) ->
+        if not (DirPath.Set.mem d m.library_safe_deps) then mark d)
+      m.library_deps
+  done;
+  fun dir -> if DirPath.Set.mem dir !full then ModeFull else ModeSafe
+
+let error_previously_safe_required dir =
+  CErrors.user_err
+    Pp.(str "Cannot unsafe-require library " ++ DirPath.print dir ++ spc() ++
+        str "because it was previously required with (safe).")
+
+(* Detect in-session conflicts with already-loaded libraries, i.e. a full
+   demand (a full root, or a normal edge from a full library) reaching a
+   library that was previously safe-required.
+
+   This is a pre-order depth-first traversal from the roots along full
+   (normal-edge) reachability, following each library's dependencies in
+   declaration order, so that the offending library reported is the first
+   one a plain require would have reached. *)
+let check_closure_conflicts ~cmd_safe ~roots contents =
+  let visited = ref DirPath.Set.empty in
+  let rec visit dir =
+    match find_library dir with
+    | Some (SafeLoaded, _) -> error_previously_safe_required dir
+    | Some (FullLoaded, _) -> ()
+    | None ->
+      if not (DirPath.Set.mem dir !visited) then begin
+        visited := DirPath.Set.add dir !visited;
+        let m = DirPath.Map.find dir contents in
+        Array.iter (fun (d, _) ->
+            if not (DirPath.Set.mem d m.library_safe_deps) then visit d)
+          m.library_deps
+      end
+  in
+  if not cmd_safe then List.iter visit roots
+
+(* Intern the closure of [modrefl], compute per-library modes, run the
+   in-session conflict checks and return the topologically-ordered list of
+   newly-interned libraries tagged with their computed mode. *)
+let intern_and_resolve_modes ~cmd_safe ~intern modrefl =
+  let needed, contents =
+    List.fold_left (rec_intern_library ~intern) ([], DirPath.Map.empty) modrefl in
+  let roots = List.map snd modrefl in
+  let needed = promote_roots needed roots in
+  List.iter (fun dir ->
+      let info = match DirPath.Map.find_opt dir contents with
+        | Some m -> Some m.library_info
+        | None -> Option.map (fun (_, m) -> m.library_info) (find_library dir)
+      in
+      Option.iter (Library_info.warn_library_info dir) info)
+    roots;
+  let mode_of = compute_modes ~cmd_safe ~roots contents in
+  check_closure_conflicts ~cmd_safe ~roots contents;
+  List.rev_map (fun (root, dir) ->
+      let m = DirPath.Map.find dir contents in
+      (mode_of dir, root, m))
+    needed
 
 let native_name_from_filename f =
   let ch = raw_intern_library f in
@@ -378,6 +483,8 @@ let native_name_from_filename f =
     which recursively loads its dependencies)
 *)
 
+(* Full-mode registration (object replay). *)
+
 let register_library m =
   let l = m.library_data in
   Declaremods.Interp.register_library
@@ -389,76 +496,15 @@ let register_library m =
   ;
   register_native_library m.library_name
 
-let register_library_syntax (root, m) =
+let register_library_syntax ~root m =
   let l = m.library_data in
   Declaremods.Synterp.register_library
     m.library_name
     l.md_syntax_objects;
   register_loaded_library ~root FullLoaded m
 
-(* Follow the semantics of Anticipate object:
-   - called at module or module type closing when a Require occurs in
-     the module or module type
-   - not called from a library (i.e. a module identified with a file)
-   [needed] is the ordered list of libraries not already loaded *)
-let cache_require needed =
-  List.iter register_library needed
-
-let load_require _ o =
-  cache_require o
-
-(* open_function is never called from here because an Anticipate object *)
-
-type require_obj = library_t list
-
-let in_require : require_obj -> obj =
-  declare_object
-    {(default_object "REQUIRE") with
-     cache_function = cache_require;
-     load_function = load_require;
-     open_function = (fun _ _ -> assert false);
-     discharge_function = (fun o -> Some o);
-     classify_function = (fun o -> Anticipate) }
-
-let cache_require_syntax needed =
-  List.iter register_library_syntax needed
-
-let load_require_syntax _ o =
-  cache_require_syntax o
-
-(* open_function is never called from here because an Anticipate object *)
-
-type require_obj_syntax = (bool * library_t) list
-
-let in_require_syntax : require_obj_syntax -> obj =
-  declare_object
-    {(default_object "REQUIRE-SYNTAX") with
-     object_stage = Summary.Stage.Synterp;
-     cache_function = cache_require_syntax;
-     load_function = load_require_syntax;
-     open_function = (fun _ _ -> assert false);
-     discharge_function = (fun o -> Some o);
-     classify_function = (fun o -> Anticipate) }
-
-(* Require libraries, import them if [export <> None], mark them for export
-   if [export = Some true] *)
-
-let warn_require_in_module =
-  CWarnings.create ~name:"require-in-module" ~category:CWarnings.CoreCategories.fragile
-    (fun () -> strbrk "Use of “Require” inside a module is fragile." ++ spc() ++
-               strbrk "It is not recommended to use this functionality in finished proof scripts.")
-
-let require_library needed =
-  if Lib.is_module_or_modtype () then warn_require_in_module ();
-  Lib.add_leaf (in_require needed)
-
-let require_library_syntax_from_dirpath ~intern modrefl =
-  let needed, contents = List.fold_left (rec_intern_library ~safe:false ~intern) ([], DirPath.Map.empty) modrefl in
-  let needed = List.rev_map (fun (root, dir) -> root, DirPath.Map.find dir contents) needed in
-  Lib.add_leaf (in_require_syntax needed);
-  List.map snd needed
-
-(* safe require *)
+(* Safe-mode registration: import the kernel structure and push FQN-only names
+   without replaying libobjects. *)
 
 let safe_require_mind_names vis sp mind mib =
   mib.Declarations.mind_packets |> Array.iteri @@ fun ind (mip:Declarations.one_inductive_body) ->
@@ -510,12 +556,12 @@ let safe_require_names ~stage dp mb =
   let sp = Libnames.make_path0 dp in
   safe_require_mod_names ~stage 1 sp mp mb
 
-let cache_one_safe_require_synterp (root, m) =
+let register_safe_library_syntax ~root m =
   safe_require_names ~stage:Synterp m.library_name
     (Safe_typing.module_of_library m.library_data.md_compiled);
   register_loaded_library ~root SafeLoaded m
 
-let cache_one_safe_require_interp m =
+let register_safe_library m =
   let compiled = m.library_data.md_compiled in
   let () =
     let mp = MPfile m.library_name in
@@ -525,7 +571,6 @@ let cache_one_safe_require_interp m =
          effects but the kernel did not forget the library. *)
       ignore(Global.lookup_module mp);
     with Not_found ->
-      (* $2 $5 $4 *)
       let mp' = Global.import compiled m.library_vm m.library_digests in
       if not (ModPath.equal mp mp') then
         anomaly (Pp.str "Unexpected disk module name.")
@@ -534,50 +579,80 @@ let cache_one_safe_require_interp m =
     (Safe_typing.module_of_library compiled);
   register_native_library m.library_name
 
-let cache_safe_require_synterp needed =
-  List.iter cache_one_safe_require_synterp needed
+(* Unified require objects. A single [Require] / [Require (safe)] now
+   registers a whole topologically-ordered closure in which each library
+   carries its computed mode: full libraries replay their objects, safe ones
+   are only imported kernel-side. Interleaving the two in one object preserves
+   the order (a full library's object replay may rely on an earlier one). *)
 
-let load_safe_require_synterp _ o =
-  cache_safe_require_synterp o
+let register_one_syntax (mode, root, m) = match mode with
+  | ModeFull -> register_library_syntax ~root m
+  | ModeSafe -> register_safe_library_syntax ~root m
 
-type safe_require_synterp = (bool * library_t) list
+let register_one_interp (mode, m) = match mode with
+  | ModeFull -> register_library m
+  | ModeSafe -> register_safe_library m
 
-let in_safe_require_synterp : safe_require_synterp -> obj =
+(* Follow the semantics of Anticipate object:
+   - called at module or module type closing when a Require occurs in
+     the module or module type
+   - not called from a library (i.e. a module identified with a file)
+   [needed] is the ordered list of libraries not already loaded *)
+let cache_require needed =
+  List.iter register_one_interp needed
+
+let load_require _ o =
+  cache_require o
+
+(* open_function is never called from here because an Anticipate object *)
+
+type require_obj = (require_mode * library_t) list
+
+let in_require : require_obj -> obj =
   declare_object
-    {(default_object "SAFE-REQUIRE-SYNTERP") with
+    {(default_object "REQUIRE") with
+     cache_function = cache_require;
+     load_function = load_require;
+     open_function = (fun _ _ -> assert false);
+     discharge_function = (fun o -> Some o);
+     classify_function = (fun o -> Anticipate) }
+
+let cache_require_syntax needed =
+  List.iter register_one_syntax needed
+
+let load_require_syntax _ o =
+  cache_require_syntax o
+
+(* open_function is never called from here because an Anticipate object *)
+
+type require_obj_syntax = (require_mode * bool * library_t) list
+
+let in_require_syntax : require_obj_syntax -> obj =
+  declare_object
+    {(default_object "REQUIRE-SYNTAX") with
      object_stage = Summary.Stage.Synterp;
-     cache_function = cache_safe_require_synterp;
-     load_function = load_safe_require_synterp;
+     cache_function = cache_require_syntax;
+     load_function = load_require_syntax;
      open_function = (fun _ _ -> assert false);
      discharge_function = (fun o -> Some o);
      classify_function = (fun o -> Anticipate) }
 
-let cache_safe_require_interp needed =
-  List.iter cache_one_safe_require_interp needed
+(* Require libraries, import them if [export <> None], mark them for export
+   if [export = Some true] *)
 
-let load_safe_require_interp _ o = cache_safe_require_interp o
+let warn_require_in_module =
+  CWarnings.create ~name:"require-in-module" ~category:CWarnings.CoreCategories.fragile
+    (fun () -> strbrk "Use of “Require” inside a module is fragile." ++ spc() ++
+               strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
-type safe_require_interp = library_t list
-
-let in_safe_require_interp : safe_require_interp -> obj =
-  declare_object
-    {(default_object "SAFE-REQUIRE-INTERP") with
-     object_stage = Summary.Stage.Interp;
-     cache_function = cache_safe_require_interp;
-     load_function = load_safe_require_interp;
-     open_function = (fun _ _ -> assert false);
-     discharge_function = (fun o -> Some o);
-     classify_function = (fun o -> Anticipate) }
-
-let safe_require_synterp ~intern modrefl =
-  let needed, contents = List.fold_left (rec_intern_library ~safe:true ~intern) ([], DirPath.Map.empty) modrefl in
-  let needed = List.rev_map (fun (root, dir) -> root, DirPath.Map.find dir contents) needed in
-  Lib.add_leaf (in_safe_require_synterp needed);
-  List.map snd needed
-
-let safe_require_interp needed =
+let require_library needed =
   if Lib.is_module_or_modtype () then warn_require_in_module ();
-  Lib.add_leaf (in_safe_require_interp needed)
+  Lib.add_leaf (in_require needed)
+
+let require_library_syntax_from_dirpath ~cmd_safe ~intern modrefl =
+  let needed = intern_and_resolve_modes ~cmd_safe ~intern modrefl in
+  Lib.add_leaf (in_require_syntax needed);
+  List.map (fun (mode, _root, m) -> (mode, m)) needed
 
 (************************************************************************)
 (*s [save_library dir] ends library [dir] and save it to the disk. *)
@@ -591,6 +666,18 @@ let current_deps () =
     else None
   in
   List.map_filter map !libraries_loaded_list
+
+let current_safe_deps () =
+  (* Among the direct dependencies (the roots of the DAG), record those that
+     are only safe-loaded so that downstream requires keep them safe. *)
+  let add acc (root, m) =
+    if root then
+      match find_library m with
+      | Some (SafeLoaded, _) -> DirPath.Set.add m acc
+      | Some (FullLoaded, _) | None -> acc
+    else acc
+  in
+  List.fold_left add DirPath.Set.empty !libraries_loaded_list
 
 let error_recursively_dependent_library dir =
   user_err
@@ -637,6 +724,7 @@ let save_library_struct ~output_native_objects dir =
     ; md_deps = Array.of_list (current_deps ())
     ; md_ocaml = Coq_config.caml_version
     ; md_info = info
+    ; md_safe_deps = current_safe_deps ()
     } in
   let md =
     { md_compiled

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -21,11 +21,14 @@ open Names
 (** Type of libraries loaded in memory *)
 type library_t
 
+(** Whether a library of a required closure is fully loaded (its objects are
+    replayed) or only safe-loaded (imported kernel-side, full-qualified names
+    only). *)
+type require_mode = ModeFull | ModeSafe
+
 (** {6 ... }
     Require = load in the environment *)
-val require_library : library_t list -> unit
-
-val safe_require_interp : library_t list -> unit
+val require_library : (require_mode * library_t) list -> unit
 
 (** Intern from a .vo file located by libresolver *)
 module Intern : sig
@@ -41,15 +44,15 @@ end
 val intern_from_file : CUnix.physical_path ->
   (library_t, Exninfo.iexn) Result.t * Intern.Provenance.t
 
+(** Intern the dependency closure of the given roots, compute per-library
+    modes ([cmd_safe] is the command mode: [false] for [Require], [true] for
+    [Require (safe)]), register the syntactic part and return the interp-side
+    closure tagged with the computed modes. *)
 val require_library_syntax_from_dirpath
-  : intern:Intern.t
+  : cmd_safe:bool
+  -> intern:Intern.t
   -> DirPath.t Loc.located list
-  -> library_t list
-
-val safe_require_synterp
-  : intern:Intern.t ->
-  DirPath.t Loc.located list ->
-  library_t list
+  -> (require_mode * library_t) list
 
 (** {6 Start the compilation of a library } *)
 

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -55,9 +55,9 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of lident
   | EVernacEndSegment of lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * qualid list
+  | EVernacSafeRequire of (Library.require_mode * Library.library_t) list * DirPath.t list * qualid list
   | EVernacRequire of
-      Library.library_t list * DirPath.t list * export_with_cats option * (qualid * import_filter_expr) list
+      (Library.require_mode * Library.library_t) list * DirPath.t list * export_with_cats option * (qualid * import_filter_expr) list
   | EVernacImport of (export_flag *
       Libobject.open_filter) *
       (Names.ModPath.t CAst.t * import_filter_expr) list
@@ -317,20 +317,20 @@ let require_locate from qidl =
 let synterp_safe_require ~intern from qidl =
   let modrefl = require_locate from qidl in
   Coq_config.gc_ramp_up @@ fun () ->
-  let needed = Library.safe_require_synterp ~intern modrefl in
+  let needed = Library.require_library_syntax_from_dirpath ~cmd_safe:true ~intern modrefl in
   needed, List.map snd modrefl
 
 let synterp_require ~intern from export qidl =
   let modrefl = require_locate from (List.map fst qidl) in
   Coq_config.gc_ramp_up @@ fun () ->
-  let filenames = Library.require_library_syntax_from_dirpath ~intern modrefl in
+  let needed = Library.require_library_syntax_from_dirpath ~cmd_safe:false ~intern modrefl in
   Option.iter (fun (export,cats) ->
       let cats = synterp_import_cats cats in
       List.iter2 (fun (_, m) (_, f) ->
           import_module_syntax_with_filter ~export cats (MPfile m) f)
         modrefl qidl)
     export;
-    filenames, List.map snd modrefl
+    needed, List.map snd modrefl
 
 (*****************************)
 (* Auxiliary file management *)

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -32,9 +32,9 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of Names.lident
   | EVernacEndSegment of Names.lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * qualid list
+  | EVernacSafeRequire of (Library.require_mode * Library.library_t) list * DirPath.t list * qualid list
   | EVernacRequire of
-      Library.library_t list * DirPath.t list * Vernacexpr.export_with_cats option * (qualid * Vernacexpr.import_filter_expr) list
+      (Library.require_mode * Library.library_t) list * DirPath.t list * Vernacexpr.export_with_cats option * (qualid * Vernacexpr.import_filter_expr) list
   | EVernacImport of (Vernacexpr.export_flag * Libobject.open_filter) *
       (Names.ModPath.t CAst.t * Vernacexpr.import_filter_expr) list
   | EVernacDeclareMLModule of Mltop.interp_fun
@@ -74,7 +74,7 @@ val synterp_require :
   Libnames.qualid option ->
   Vernacexpr.export_with_cats option ->
   (Libnames.qualid * Vernacexpr.import_filter_expr) list ->
-  Library.library_t list * DirPath.t list
+  (Library.require_mode * Library.library_t) list * DirPath.t list
 
 (** [synterp_control] is the main entry point of the syntactic interpretation phase *)
 val synterp_control :

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1668,11 +1668,11 @@ let warn_require_in_section =
                strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
 let vernac_safe_require_interp needed modrefl qidl =
-if Lib.sections_are_opened () then warn_require_in_section ();
+  if Lib.sections_are_opened () then warn_require_in_section ();
   if Dumpglob.dump () then
     List.iter2 (fun {CAst.loc} dp -> Dumpglob.dump_libref ?loc dp "lib") qidl modrefl;
   Coq_config.gc_ramp_up @@ fun () ->
-  Library.safe_require_interp needed
+  Library.require_library needed
 
 let vernac_require_interp needed modrefl export qidl =
   if Lib.sections_are_opened () then warn_require_in_section ();

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -32,7 +32,7 @@ val vernac_require
 
 (** Interp phase of the require command *)
 val vernac_require_interp
-  : Library.library_t list
+  : (Library.require_mode * Library.library_t) list
   -> Names.DirPath.t list
   -> Vernacexpr.export_with_cats option
   -> (Libnames.qualid * Vernacexpr.import_filter_expr) list


### PR DESCRIPTION
Follow-up for rocq-prover/rocq#22291, offered against your `safrequire` branch (base 71e295ba3c): persist safe-require-ness into the `.vo` so downstream `Require`s keep safe-required dependencies safe (the "could do a full require of safe-required deps" TODO goes the other way: safe stays safe).

- `md_safe_deps : DirPath.Set.t` in `summary_disk`, written from the load-status table at save time
- `Require` interns the whole closure first, then a worklist fixpoint computes per-library modes: Full propagates only along normal edges (edge A→D is safe iff D ∈ A's recorded safe deps); registration then runs in the usual topo order with per-lib modes
- the base PR's four require libobjects unify into two per-stage objects carrying `(require_mode * library_t)` lists — the all-full case replays identically to before
- conflict error unchanged (`previously required with (safe)`), found by DFS from the roots so it names the same library as before
- checker synced (`v_libsum` + checkLibrary mirror); `vo_version` not bumped (version-derived)

Tests: a multi-file misc test proves a downstream `Require A` keeps A's safe-required dep safe (no implicits, `Fail Require` errors) with a full-load control; base SafeRequire output unchanged; full misc/output/coqchk groups pass; manual diamond/multi-level checks done.

Note: conflicts with the Import/Export offer; a combined PR reconciling them is offered separately.

Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
