### PR TITLE
Require (safe): Import/Export + dependency propagation (combined)

### DIFF
--- a/checker/checkLibrary.ml
+++ b/checker/checkLibrary.ml
@@ -285,6 +285,7 @@ type summary_disk = {
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
   md_info : library_info;
+  md_safe_deps : DirPath.Set.t;
 }
 
 type library_objects

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -613,7 +613,7 @@ let v_compiled_lib =
 (** Toplevel structures in a vo (see Cic.mli) *)
 
 let v_libsum =
-  v_tuple_c ("summary", [|v_dp;v_deps;v_string;v_any|])
+  v_tuple_c ("summary", [|v_dp;v_deps;v_string;v_any;v_set v_dp|])
 
 let v_lib =
   v_tuple_c ("library",[|v_compiled_lib;v_any;v_any|])

--- a/doc/changelog/08-vernac-commands-and-options/22291-safe-require-propagation.rst
+++ b/doc/changelog/08-vernac-commands-and-options/22291-safe-require-propagation.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  A library compiled with :cmd:`Require` :n:`(safe)` now keeps those safe
+  dependencies safe for its downstream users: a plain :cmd:`Require` of such a
+  library loads it fully but only safe-loads the dependencies it had itself
+  safe-required (and, transitively, their dependencies). The set of
+  safe-required direct dependencies is recorded in each ``.vo`` file
+  (`#22291 <https://github.com/rocq-prover/rocq/pull/22291>`_,
+  by Gaëtan Gilbert and Jason Gross).

--- a/test-suite/misc/safe-require-export-import.sh
+++ b/test-suite/misc/safe-require-export-import.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Integration of Require (safe) Import/Export support and safe-dependency
+# propagation.  A does [Require (safe) Export CRelationClasses], so A both
+# keeps CRelationClasses safe for its downstream users (propagation) and
+# records the ExportObject that re-exports it (import/export support).  B
+# requires A fully, then imports it: propagation keeps CRelationClasses safe
+# in B, and [Import A] replays the ExportObject, whose import of the
+# safe-loaded CRelationClasses exercises the safe branch of Declaremods'
+# import machinery to push the short names.  Neither feature alone can make
+# this work.
+
+set -e
+
+export PATH=$BIN:$PATH
+
+cd misc/safe-require-export-import
+rm -rf _test
+mkdir _test
+cp A.v B.v B.out _test
+cd _test
+
+# A re-exports the safe-required CRelationClasses.
+rocq c -R . Top A.v
+
+# Requiring A fully keeps CRelationClasses safe (short name FQN-only before
+# import), [Import A] then exposes the short name, CRelationClasses stays safe
+# (no implicit arguments), and a plain require of it is still rejected.
+rocq c -test-mode -R . Top B.v > B.real 2>&1
+diff -u --strip-trailing-cr B.out B.real

--- a/test-suite/misc/safe-require-export-import/A.v
+++ b/test-suite/misc/safe-require-export-import/A.v
@@ -1,0 +1,4 @@
+(* A re-exports a safe-required library.  Compiling A records both the
+   safe-require of CRelationClasses (so it stays safe for A's downstream
+   users) and the standard ExportObject that re-exports it on [Import A]. *)
+Require (safe) Export Corelib.Classes.CRelationClasses.

--- a/test-suite/misc/safe-require-export-import/B.out
+++ b/test-suite/misc/safe-require-export-import/B.out
@@ -1,0 +1,17 @@
+CRelationClasses.flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+File "./B.v", line 8, characters 11-15:
+The command has indeed failed with message:
+The reference flip was not found in the current environment.
+flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+flip@{u u0 u1} : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+
+flip is universe polymorphic
+Arguments flip A B C f x y
+flip is transparent
+Expands to: Constant Corelib.Classes.CRelationClasses.flip
+File "./B.v", line 23, characters 0-46:
+The command has indeed failed with message:
+Cannot unsafe-require library Corelib.Classes.CRelationClasses
+because it was previously required with (safe).

--- a/test-suite/misc/safe-require-export-import/B.v
+++ b/test-suite/misc/safe-require-export-import/B.v
@@ -1,0 +1,23 @@
+(* B requires A fully.  Because A safe-required CRelationClasses, propagation
+   keeps CRelationClasses safe in B's session too; before importing A only its
+   fully-qualified names resolve. *)
+Require A.
+
+(* the qualified name resolves, the short one does not (safe = FQN only) *)
+Check Corelib.Classes.CRelationClasses.flip.
+Fail Check flip.
+
+(* Importing A replays A's ExportObject; importing the safe-loaded
+   CRelationClasses it carries hits the safe branch of Declaremods' import
+   machinery (no ModObjs entry to collect) and pushes the short names.  This
+   is only reachable with both Import/Export support and safe-dependency
+   propagation: without propagation CRelationClasses would be fully loaded in
+   B, without Import/Export support there would be no safe short-name walk. *)
+Import A.
+Check flip.
+
+(* CRelationClasses is still only safe-loaded in B: no implicit arguments. *)
+About Corelib.Classes.CRelationClasses.flip.
+
+(* and a plain require of the propagated-safe library is still rejected *)
+Fail Require Corelib.Classes.CRelationClasses.

--- a/test-suite/misc/safe-require-propagation.sh
+++ b/test-suite/misc/safe-require-propagation.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# A library compiled with [Require (safe) M] keeps M (and M's dependencies)
+# safe for its downstream users: requiring such a library fully loads it but
+# only safe-loads its safe dependencies.
+
+set -e
+
+export PATH=$BIN:$PATH
+
+cd misc/safe-require-propagation
+rm -rf _test
+mkdir _test
+cp A.v B.v C.v B.out C.out _test
+cd _test
+
+# A safe-requires CMorphisms (which depends on CRelationClasses).
+rocq c -R . Top A.v
+
+# Requiring A fully must keep CRelationClasses safe (no implicit arguments,
+# and a plain require of it is still rejected).
+rocq c -test-mode -R . Top B.v > B.real 2>&1
+diff -u --strip-trailing-cr B.out B.real
+
+# Control: fully requiring CRelationClasses first, then A, works and keeps
+# CRelationClasses fully loaded.
+rocq c -test-mode -R . Top C.v > C.real 2>&1
+diff -u --strip-trailing-cr C.out C.real

--- a/test-suite/misc/safe-require-propagation/A.v
+++ b/test-suite/misc/safe-require-propagation/A.v
@@ -1,0 +1,1 @@
+Require (safe) Corelib.Classes.CMorphisms. (* depends on CRelationClasses *)

--- a/test-suite/misc/safe-require-propagation/B.out
+++ b/test-suite/misc/safe-require-propagation/B.out
@@ -1,0 +1,13 @@
+CRelationClasses.flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+CRelationClasses.flip@{u u0 u1} :
+forall A B C : Type, (A -> B -> C) -> B -> A -> C
+
+CRelationClasses.flip is universe polymorphic
+Arguments CRelationClasses.flip A B C f x y
+CRelationClasses.flip is transparent
+Expands to: Constant Corelib.Classes.CRelationClasses.flip
+File "./B.v", line 11, characters 0-46:
+The command has indeed failed with message:
+Cannot unsafe-require library Corelib.Classes.CRelationClasses
+because it was previously required with (safe).

--- a/test-suite/misc/safe-require-propagation/B.v
+++ b/test-suite/misc/safe-require-propagation/B.v
@@ -1,0 +1,11 @@
+(* A was compiled with [Require (safe) CMorphisms]: requiring A fully must
+   still keep CRelationClasses (a safe dependency, reached only through the
+   safe-required CMorphisms) safe. *)
+Require A.
+
+(* no implicit arguments, but can be used *)
+Type Corelib.Classes.CRelationClasses.flip.
+About Corelib.Classes.CRelationClasses.flip.
+
+(* a plain require of a propagated-safe library is still rejected *)
+Fail Require Corelib.Classes.CRelationClasses.

--- a/test-suite/misc/safe-require-propagation/C.out
+++ b/test-suite/misc/safe-require-propagation/C.out
@@ -1,0 +1,9 @@
+CRelationClasses.flip@{u u0 u1} :
+forall {A B C : Type}, (A -> B -> C) -> B -> A -> C
+
+CRelationClasses.flip is universe polymorphic
+Arguments CRelationClasses.flip {A B C}%_type_scope f%_function_scope x y
+CRelationClasses.flip is transparent
+Expands to: Constant Corelib.Classes.CRelationClasses.flip
+Declared in
+library Corelib.Classes.CRelationClasses, line 32, characters 11-15

--- a/test-suite/misc/safe-require-propagation/C.v
+++ b/test-suite/misc/safe-require-propagation/C.v
@@ -1,0 +1,5 @@
+(* Control: fully requiring CRelationClasses before A makes it fully loaded;
+   requiring A then reuses the full library silently. *)
+Require Corelib.Classes.CRelationClasses.
+Require A.
+About Corelib.Classes.CRelationClasses.flip.

--- a/test-suite/output/SafeRequireImport.out
+++ b/test-suite/output/SafeRequireImport.out
@@ -1,0 +1,17 @@
+File "./output/SafeRequireImport.v", line 7, characters 11-15:
+The command has indeed failed with message:
+The reference flip was not found in the current environment.
+CRelationClasses.flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+flip
+     : forall A B C : Type, (A -> B -> C) -> B -> A -> C
+respectful
+     : forall A B : Type, crelation A -> crelation B -> crelation (A -> B)
+arrow
+     : Type -> Type -> Type
+unary_operation
+     : Type -> Type
+File "./output/SafeRequireImport.v", line 30, characters 0-30:
+The command has indeed failed with message:
+Cannot unsafe-require library Corelib.Classes.CRelationClasses
+because it was previously required with (safe).

--- a/test-suite/output/SafeRequireImport.v
+++ b/test-suite/output/SafeRequireImport.v
@@ -1,0 +1,30 @@
+(* Test Import/Export support for Require (safe).
+   See also output/SafeRequire.v for the plain (no-import) behaviour. *)
+
+(* 1. Plain Require (safe): only fully-qualified names are visible.
+   The short name [flip] does not resolve, the qualified one does. *)
+Require (safe) CRelationClasses.
+Fail Check flip.
+Check CRelationClasses.flip.
+
+(* 2. A standalone Import on the already safe-loaded library pushes the
+   short names (this exercises the safe branch of Declaremods' import
+   machinery, since the library has no ModObjs entry). *)
+Import CRelationClasses.
+Check flip.
+
+(* 3. Require (safe) Import: the short name is available immediately. *)
+Require (safe) Import CMorphisms.
+Check respectful.
+
+(* 4. Require (safe) Export: like Import for the current session, and
+   records the standard ExportObject for re-export downstream. *)
+Require (safe) Export CRelationClasses.
+Check arrow.
+
+(* 5. The From ... Require (safe) Import form also parses and imports. *)
+From Corelib Require (safe) Import RelationClasses.
+Check unary_operation.
+
+(* A plain Require of a safe-imported library still errors. *)
+Fail Require CRelationClasses.

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -226,6 +226,7 @@ module type StagedModS = sig
   val load_keep : int -> full_path -> ModPath.t -> keep_objects -> unit
   val load_escape : int -> full_path -> ModPath.t -> escape_objects -> unit
   val load_module : int -> full_path -> ModPath.t -> substitutive_objects -> unit
+  val load_safe_library : DirPath.t -> Mod_declarations.module_body -> unit
   val import_modules : export:Lib.export_flag -> (open_filter * ModPath.t) list -> unit
 
   val add_leaf : Libobject.t -> unit
@@ -436,6 +437,115 @@ module ModObjs :
    let all () = !table
  end
 
+(** {6 SafeLibs : the set of libraries loaded through [Require (safe)]}
+
+   A [Require (safe)] library is imported in the kernel but no libobject
+   replay is performed, so it has no entry in [ModObjs] and cannot be
+   imported through the usual object-collection machinery. We record the
+   set of such libraries (per stage) so that [Import]/[Export] of a
+   safe-loaded library can push names directly by walking the kernel
+   module structure instead. *)
+
+module SafeLibs :
+ sig
+   val register : DirPath.t -> Mod_declarations.module_body -> unit
+   val find : DirPath.t -> Mod_declarations.module_body option
+ end =
+ struct
+   let table =
+     Summary.ref ~stage:Actions.stage (DirPath.Map.empty : Mod_declarations.module_body DirPath.Map.t)
+       ~name:(Actions.modobjs_table_name ^ "-SAFE-LIBS")
+   let register dp mb = (table := DirPath.Map.add dp mb !table)
+   let find dp = DirPath.Map.find_opt dp !table
+ end
+
+(** {6 Name pushing for [Require (safe)] libraries}
+
+   These walk the kernel module structure of a safe-loaded library and
+   push short names into the nametab. The walk carries the module-nesting
+   depth [i] (the library module is depth 1); an object directly inside a
+   module at depth [i] has [i] path components stripped from its full name,
+   hence a "[Until]-index" of [i+1].
+
+   The visibility to push at is computed by [vis] from that [Until]-index:
+   - at load time, [Until k], so only fully-qualified(-ish) names are
+     visible (as a plain [Require (safe)] should);
+   - at import time, [Exactly (k-1)], matching the depth [open_object]
+     would use for the same object during a normal [Import] (a top-level
+     constant of the library becomes visible under its bare name). The top
+     library module name itself ([Until]-index 1) is not (re-)pushed on
+     import, mirroring normal library import which never re-pushes it.
+
+   Constants/inductives/constructors exist only at the [Interp] stage;
+   module and module type short names at [Synterp]. *)
+
+let safe_require_mind_names vis sp mind mib =
+  mib.Declarations.mind_packets |> Array.iteri @@ fun ind (mip:Declarations.one_inductive_body) ->
+  let ind = (mind, ind) in
+  let () = Option.iter (fun vis -> Nametab.push vis (Libnames.add_path_suffix sp mip.mind_typename) (GlobRef.IndRef ind)) vis in
+  mip.mind_consnames |> Array.iteri @@ fun ctor cna ->
+  Option.iter (fun vis -> Nametab.push vis (Libnames.add_path_suffix sp cna) (GlobRef.ConstructRef (ind, ctor+1))) vis
+
+let rec safe_require_mod_names ~vis i sp mp mb =
+  let () = match Actions.stage with
+    | Summary.Stage.Synterp -> Option.iter (fun v -> Nametab.push_module v sp mp) (vis i)
+    | Interp -> ()
+  in
+  match Mod_declarations.mod_type mb with
+  | MoreFunctor _ -> ()
+  | NoFunctor contents ->
+    contents |> List.iter @@ fun (lab, contents) ->
+    match contents with
+    | Declarations.SFBrules _ ->
+      ()
+    | SFBconst _ ->
+      begin match Actions.stage with
+      | Synterp -> ()
+      | Interp ->
+        let kn = Global.constant_of_delta_kn (KerName.make mp lab) in
+        let sp = Libnames.add_path_suffix sp lab in
+        Option.iter (fun v -> Nametab.push v sp (GlobRef.ConstRef kn)) (vis (i+1))
+      end
+    | SFBmind mib ->
+      begin match Actions.stage with
+      | Synterp -> ()
+      | Interp ->
+        let mind = Global.mind_of_delta_kn (KerName.make mp lab) in
+        safe_require_mind_names (vis (i+1)) sp mind mib
+      end
+    | SFBmodtype _ ->
+      begin match Actions.stage with
+      | Synterp ->
+        let mp = ModPath.MPdot (mp, lab) in
+        let sp = Libnames.add_path_suffix sp lab in
+        Option.iter (fun v -> Nametab.push_modtype v sp mp) (vis (i+1))
+      | Interp -> ()
+      end
+    | SFBmodule mb ->
+      safe_require_mod_names ~vis (i+1) (Libnames.add_path_suffix sp lab) (MPdot (mp,lab)) mb
+
+let safe_require_names ~vis dp mb =
+  let mp = ModPath.MPfile dp in
+  let sp = Libnames.make_path0 dp in
+  safe_require_mod_names ~vis 1 sp mp mb
+
+(** Push the fully-qualified-only ([Until]) names of a safe-loaded library
+    and record it as safe-loaded (so a later [Import]/[Export] can find its
+    module structure). [mb] is the kernel module body of the library, which
+    at the [Synterp] stage cannot be recovered from the kernel (it is not
+    imported there) and so is supplied by the caller. *)
+let load_safe_library dp mb =
+  safe_require_names ~vis:(fun k -> Some (Nametab.Until k)) dp mb;
+  SafeLibs.register dp mb
+
+(** Push the short ([Exactly]) names of a safe-loaded library, as done by
+    [Import]. Known divergence from a real [Import]: the kernel structure
+    carries no vernacular locality info ([ImportNeedQualified] from a
+    [Local Definition] lives only in libobjects), so this may expose short
+    names that a real [Import] would keep qualified-only. *)
+let import_safe_library dp mb =
+  safe_require_names ~vis:(fun k -> if k <= 1 then None else Some (Nametab.Exactly (k-1))) dp mb
+
  open Expand
 
 (** {6 Declaration of module substitutive objects} *)
@@ -535,6 +645,13 @@ let mark_object f obj (exports,acc) =
   (exports, (f,obj)::acc)
 
 let rec collect_module (f,mp) acc =
+  (* A [Require (safe)] library has no [ModObjs] entry; importing it pushes
+     short names directly by walking the kernel structure. This must take
+     precedence over the (missing) [ModObjs] lookup. Filters are ignored:
+     there are no libobjects/categories to filter on. *)
+  match (match mp with MPfile dp -> Option.map (fun mb -> (dp, mb)) (SafeLibs.find dp) | _ -> None) with
+  | Some (dp, mb) -> import_safe_library dp mb; acc
+  | None ->
   try
     (* May raise Not_found for unknown module and for functors *)
     let modobjs = ModObjs.get mp in
@@ -1557,6 +1674,9 @@ let register_library dir (objs:library_objects) =
   SynterpVisitor.load_escape 2 sp mp escapeobjs;
   SynterpVisitor.load_keep 2 sp mp keepobjs
 
+let register_safe_library dir mb =
+  SynterpVisitor.load_safe_library dir mb
+
 let import_modules = SynterpVisitor.import_modules
 
 let import_module f ~export mp =
@@ -1648,6 +1768,9 @@ let register_library dir cenv (objs:library_objects) digest vmtab =
   InterpVisitor.load_module 1 sp mp ([],Objs sobjs);
   InterpVisitor.load_escape 1 sp mp escapeobjs;
   InterpVisitor.load_keep 1 sp mp keepobjs
+
+let register_safe_library dir mb =
+  InterpVisitor.load_safe_library dir mb
 
 let import_modules = InterpVisitor.import_modules
 

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -84,6 +84,11 @@ val import_modules : export:Lib.export_flag -> (Libobject.open_filter * ModPath.
 
 val register_library : library_name -> library_objects -> unit
 
+(** Register a [Require (safe)] library: push its fully-qualified-only
+    names by walking the kernel module structure (no libobject replay) and
+    record it as safe-loaded so a later [Import]/[Export] can find it. *)
+val register_safe_library : library_name -> Mod_declarations.module_body -> unit
+
 val close_section : unit -> unit
 
 end
@@ -136,6 +141,12 @@ val register_library :
   Safe_typing.compiled_library -> library_objects -> Safe_typing.vodigest ->
   Vmlibrary.on_disk ->
   unit
+
+(** Register a [Require (safe)] library: push its fully-qualified-only
+    names by walking the kernel module structure (no libobject replay) and
+    record it as safe-loaded so a later [Import]/[Export] can find it. The
+    caller must have already imported the library into the kernel. *)
+val register_safe_library : library_name -> Mod_declarations.module_body -> unit
 
 (** [import_module export mp] imports the module [mp].
    It modifies Nametab and performs the [open_object] function for

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -741,11 +741,12 @@ GRAMMAR EXTEND Gram
           { VernacSynterp (VernacExtraDependency (ns, f, Option.map Id.of_string id)) }
 
       (* Requiring an already compiled module *)
-      | IDENT "Require"; "("; IDENT "safe"; ")"; qidl = LIST1 qualid ->
-          { VernacSynterp (VernacSafeRequire (None, qidl)) }
-      | IDENT "From" ; ns = global ; IDENT "Require"; "("; IDENT "safe"; ")";
+      | IDENT "Require"; "("; IDENT "safe"; ")"; export = safe_export_token;
         qidl = LIST1 qualid ->
-        { VernacSynterp (VernacSafeRequire (Some ns, qidl)) }
+          { VernacSynterp (VernacSafeRequire (None, export, qidl)) }
+      | IDENT "From" ; ns = global ; IDENT "Require"; "("; IDENT "safe"; ")";
+        export = safe_export_token; qidl = LIST1 qualid ->
+        { VernacSynterp (VernacSafeRequire (Some ns, export, qidl)) }
 
       (* Requiring an already compiled module *)
       | IDENT "Require"; test_unsafe_require; export = export_token; qidl = LIST1 filtered_import ->
@@ -780,6 +781,11 @@ GRAMMAR EXTEND Gram
   export_token:
     [ [ IDENT "Import"; cats = OPT import_categories -> { Some (Import,cats) }
       | IDENT "Export"; cats = OPT import_categories -> { Some (Export,cats) }
+      |  -> { None } ] ]
+  ;
+  safe_export_token:
+    [ [ IDENT "Import" -> { Some Import }
+      | IDENT "Export" -> { Some Export }
       |  -> { None } ] ]
   ;
   ext_module_type:

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -458,60 +458,12 @@ let require_library_syntax_from_dirpath ~intern modrefl =
   Lib.add_leaf (in_require_syntax needed);
   List.map snd needed
 
-(* safe require *)
-
-let safe_require_mind_names vis sp mind mib =
-  mib.Declarations.mind_packets |> Array.iteri @@ fun ind (mip:Declarations.one_inductive_body) ->
-  let ind = (mind, ind) in
-  let () = Nametab.push vis (Libnames.add_path_suffix sp mip.mind_typename) (IndRef ind) in
-  mip.mind_consnames |> Array.iteri @@ fun ctor cna ->
-  Nametab.push vis (Libnames.add_path_suffix sp cna) (ConstructRef (ind, ctor+1))
-
-let rec safe_require_mod_names ~stage i sp mp mb =
-  let () = match stage with
-    | Summary.Stage.Synterp -> Nametab.push_module (Until i) sp mp
-    | Interp -> ()
-  in
-  match Mod_declarations.mod_type mb with
-  | MoreFunctor _ -> ()
-  | NoFunctor contents ->
-    contents |> List.iter @@ fun (lab, contents) ->
-    match contents with
-    | Declarations.SFBrules _ ->
-      ()
-    | SFBconst _ ->
-      begin match stage with
-      | Synterp -> ()
-      | Interp ->
-        let kn = Global.constant_of_delta_kn (KerName.make mp lab) in
-        let sp = Libnames.add_path_suffix sp lab in
-        Nametab.push (Until (i+1)) sp (ConstRef kn)
-      end
-    | SFBmind mib ->
-      begin match stage with
-      | Synterp -> ()
-      | Interp ->
-        let mind = Global.mind_of_delta_kn (KerName.make mp lab) in
-        safe_require_mind_names (Until (i+1)) sp mind mib
-      end
-    | SFBmodtype _ ->
-      begin match stage with
-      | Synterp ->
-        let mp = ModPath.MPdot (mp, lab) in
-        let sp = Libnames.add_path_suffix sp lab in
-        Nametab.push_modtype (Until (i+1)) sp mp
-      | Interp -> ()
-      end
-    | SFBmodule mb ->
-      safe_require_mod_names ~stage (i+1) (Libnames.add_path_suffix sp lab) (MPdot (mp,lab)) mb
-
-let safe_require_names ~stage dp mb =
-  let mp = ModPath.MPfile dp in
-  let sp = Libnames.make_path0 dp in
-  safe_require_mod_names ~stage 1 sp mp mb
+(* safe require: the kernel-side import and the name-pushing walk live in
+   declaremods.ml (see [Declaremods.*.register_safe_library]); here we only
+   drive them and maintain library.ml's bookkeeping tables. *)
 
 let cache_one_safe_require_synterp (root, m) =
-  safe_require_names ~stage:Synterp m.library_name
+  Declaremods.Synterp.register_safe_library m.library_name
     (Safe_typing.module_of_library m.library_data.md_compiled);
   register_loaded_library ~root SafeLoaded m
 
@@ -525,12 +477,11 @@ let cache_one_safe_require_interp m =
          effects but the kernel did not forget the library. *)
       ignore(Global.lookup_module mp);
     with Not_found ->
-      (* $2 $5 $4 *)
       let mp' = Global.import compiled m.library_vm m.library_digests in
       if not (ModPath.equal mp mp') then
         anomaly (Pp.str "Unexpected disk module name.")
   in
-  safe_require_names ~stage:Interp m.library_name
+  Declaremods.Interp.register_safe_library m.library_name
     (Safe_typing.module_of_library compiled);
   register_native_library m.library_name
 

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -91,6 +91,10 @@ type summary_disk = {
   md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
   md_ocaml : string;
   md_info : Library_info.t;
+  (* Subset of the direct dependencies (i.e. of the dirpaths appearing in
+     [md_deps]) that were only safe-required (SafeLoaded) when this library
+     was compiled. Downstream requires must keep these dependencies safe. *)
+  md_safe_deps : DirPath.Set.t;
 }
 
 (*s Modules loaded in memory contain the following informations. They are
@@ -100,6 +104,7 @@ type library_t = {
   library_name : compilation_unit_name;
   library_data : library_disk;
   library_deps : (compilation_unit_name * Safe_typing.vodigest) array;
+  library_safe_deps : DirPath.Set.t;
   library_digests : Safe_typing.vodigest;
   library_info : Library_info.t;
   library_vm : Vmlibrary.on_disk;
@@ -238,6 +243,7 @@ let mk_library sd md digests vm =
     library_name     = sd.md_name;
     library_data     = md;
     library_deps     = sd.md_deps;
+    library_safe_deps = sd.md_safe_deps;
     library_digests  = digests;
     library_info     = sd.md_info;
     library_vm = vm;
@@ -303,44 +309,43 @@ let () = CErrors.register_handler (function
 let error_in_intern provenance dir (exn, info) =
   Exninfo.iraise (InternError { exn; provenance; dir }, info)
 
-(* Returns the digest of a library, checks both caches to see what is loaded *)
-let rec intern_library ~safe ~root ~intern (needed, contents as acc) dir =
-  (* Look if in the current logical environment *)
+(* Intern a library and its dependency closure.
+
+   Unlike a plain load, safe-ness is not decided during interning: we
+   first intern the whole closure (skipping already-loaded libraries,
+   whose dependencies are already loaded), and only afterwards compute a
+   per-library effective mode (see [compute_modes]) from the recorded
+   safe-dependency edges. This keeps a safe dependency of a fully-loaded
+   library safe for the current session too. *)
+let rec intern_library ~intern (needed, contents as acc) dir =
+  (* Look if in the current logical environment: already-loaded libraries
+     (whether full or safe) are terminal, their deps are already loaded. *)
   match find_library dir with
-  | Some (load_status, loaded_lib) ->
-    begin match safe, load_status with
-    | _, FullLoaded | true, _ -> loaded_lib, acc
-    | false, SafeLoaded ->
-      (* we could do a full require of this library and any SafeLoaded deps
-         but would need to make name pushing idempotent (otherwise it will error "foo already exists")
-         or somehow separate it from libobjects so that we can do nonlogical require without re-pushing names *)
-      CErrors.user_err
-        Pp.(str "Cannot unsafe-require library " ++ DirPath.print dir ++ spc() ++
-            str "because it was previously required with (safe).")
-    end
+  | Some _ -> acc
   | None ->
     (* Look if already listed in the accumulator *)
     match DirPath.Map.find_opt dir contents with
-    | Some interned_lib ->
-      interned_lib, acc
+    | Some _ ->
+      acc
     | None ->
       (* We intern the library, and then intern the deps *)
       match intern dir with
       | Ok m, provenance ->
         check_library_expected_name ~provenance dir m.library_name;
-        m, intern_library_deps ~safe ~root ~intern acc dir m
+        intern_library_deps ~intern acc dir m
       | Error iexn, provenance ->
         error_in_intern provenance dir iexn
 
-and intern_library_deps ~safe ~root ~intern libs dir m =
+and intern_library_deps ~intern (needed, contents) dir m =
+  let contents = DirPath.Map.add dir m contents in
   let needed, contents =
-    Array.fold_left (intern_mandatory_library ~safe ~intern dir)
-      libs m.library_deps in
-  ((root, dir) :: needed, DirPath.Map.add dir m contents )
+    Array.fold_left (intern_mandatory_library ~intern dir)
+      (needed, contents) m.library_deps in
+  ((false, dir) :: needed, contents)
 
-and intern_mandatory_library ~safe ~intern caller libs (dir,d) =
-  let m, libs = intern_library ~safe ~root:false ~intern libs dir in
-  let digest = m.library_digests in
+and intern_mandatory_library ~intern caller (needed, contents) (dir,d) =
+  let needed, contents = intern_library ~intern (needed, contents) dir in
+  let digest = digest_of_dep ~contents dir in
   let () = if not (Safe_typing.digest_match ~actual:digest ~required:d) then
     let from = library_full_filename caller in
     user_err
@@ -349,12 +354,112 @@ and intern_mandatory_library ~safe ~intern caller libs (dir,d) =
        str ") makes inconsistent assumptions over library " ++
        DirPath.print dir)
   in
-  libs
+  (needed, contents)
 
-let rec_intern_library ~safe ~intern libs (loc, dir) =
-  let m, libs = intern_library ~safe ~root:true ~intern libs dir in
-  Library_info.warn_library_info m.library_name m.library_info;
-  libs
+and digest_of_dep ~contents dir =
+  match DirPath.Map.find_opt dir contents with
+  | Some m -> m.library_digests
+  | None ->
+    match find_library dir with
+    | Some (_, m) -> m.library_digests
+    | None ->
+      anomaly Pp.(str "Missing library " ++ DirPath.print dir ++
+                  str " while interning dependencies.")
+
+let rec_intern_library ~intern (needed, contents) (_loc, dir) =
+  intern_library ~intern (needed, contents) dir
+
+(* [needed] is built dependencies-first (each dir is prepended after its
+   deps). A dir added as a dependency and then reached again as a root keeps
+   its original (earlier) position; mark such positions as roots. *)
+let promote_roots needed roots =
+  let roots = List.fold_left (fun s d -> DirPath.Set.add d s) DirPath.Set.empty roots in
+  List.map (fun (root, d) -> (root || DirPath.Set.mem d roots), d) needed
+
+(* Effective load mode computed for each library of an interned closure. *)
+type require_mode = ModeFull | ModeSafe
+
+(* Compute, for each newly-interned library of the closure, whether it must
+   be fully loaded or may be safe-loaded.
+
+   Roots get the command mode ([ModeFull] for [Require], [ModeSafe] for
+   [Require (safe)]). An edge A -> D is "safe" iff D belongs to A's recorded
+   safe dependencies ([library_safe_deps]), otherwise "normal". A library is
+   [ModeFull] iff it is reachable from a [ModeFull] root through a chain of
+   normal edges; otherwise it is [ModeSafe].
+
+   Fullness only grows, so this is a monotone fixpoint reached by a worklist
+   seeded with the full roots and propagated along normal edges. *)
+let compute_modes ~cmd_safe ~roots contents =
+  let full = ref DirPath.Set.empty in
+  let queue = Queue.create () in
+  let mark dir =
+    if DirPath.Map.mem dir contents && not (DirPath.Set.mem dir !full) then begin
+      full := DirPath.Set.add dir !full;
+      Queue.add dir queue
+    end
+  in
+  if not cmd_safe then List.iter mark roots;
+  while not (Queue.is_empty queue) do
+    let dir = Queue.pop queue in
+    let m = DirPath.Map.find dir contents in
+    Array.iter (fun (d, _) ->
+        if not (DirPath.Set.mem d m.library_safe_deps) then mark d)
+      m.library_deps
+  done;
+  fun dir -> if DirPath.Set.mem dir !full then ModeFull else ModeSafe
+
+let error_previously_safe_required dir =
+  CErrors.user_err
+    Pp.(str "Cannot unsafe-require library " ++ DirPath.print dir ++ spc() ++
+        str "because it was previously required with (safe).")
+
+(* Detect in-session conflicts with already-loaded libraries, i.e. a full
+   demand (a full root, or a normal edge from a full library) reaching a
+   library that was previously safe-required.
+
+   This is a pre-order depth-first traversal from the roots along full
+   (normal-edge) reachability, following each library's dependencies in
+   declaration order, so that the offending library reported is the first
+   one a plain require would have reached. *)
+let check_closure_conflicts ~cmd_safe ~roots contents =
+  let visited = ref DirPath.Set.empty in
+  let rec visit dir =
+    match find_library dir with
+    | Some (SafeLoaded, _) -> error_previously_safe_required dir
+    | Some (FullLoaded, _) -> ()
+    | None ->
+      if not (DirPath.Set.mem dir !visited) then begin
+        visited := DirPath.Set.add dir !visited;
+        let m = DirPath.Map.find dir contents in
+        Array.iter (fun (d, _) ->
+            if not (DirPath.Set.mem d m.library_safe_deps) then visit d)
+          m.library_deps
+      end
+  in
+  if not cmd_safe then List.iter visit roots
+
+(* Intern the closure of [modrefl], compute per-library modes, run the
+   in-session conflict checks and return the topologically-ordered list of
+   newly-interned libraries tagged with their computed mode. *)
+let intern_and_resolve_modes ~cmd_safe ~intern modrefl =
+  let needed, contents =
+    List.fold_left (rec_intern_library ~intern) ([], DirPath.Map.empty) modrefl in
+  let roots = List.map snd modrefl in
+  let needed = promote_roots needed roots in
+  List.iter (fun dir ->
+      let info = match DirPath.Map.find_opt dir contents with
+        | Some m -> Some m.library_info
+        | None -> Option.map (fun (_, m) -> m.library_info) (find_library dir)
+      in
+      Option.iter (Library_info.warn_library_info dir) info)
+    roots;
+  let mode_of = compute_modes ~cmd_safe ~roots contents in
+  check_closure_conflicts ~cmd_safe ~roots contents;
+  List.rev_map (fun (root, dir) ->
+      let m = DirPath.Map.find dir contents in
+      (mode_of dir, root, m))
+    needed
 
 let native_name_from_filename f =
   let ch = raw_intern_library f in
@@ -378,6 +483,8 @@ let native_name_from_filename f =
     which recursively loads its dependencies)
 *)
 
+(* Full-mode registration (object replay). *)
+
 let register_library m =
   let l = m.library_data in
   Declaremods.Interp.register_library
@@ -389,12 +496,54 @@ let register_library m =
   ;
   register_native_library m.library_name
 
-let register_library_syntax (root, m) =
+let register_library_syntax ~root m =
   let l = m.library_data in
   Declaremods.Synterp.register_library
     m.library_name
     l.md_syntax_objects;
   register_loaded_library ~root FullLoaded m
+
+(* Safe-mode registration: the kernel-side import and the name-pushing walk
+   live in declaremods.ml (see [Declaremods.*.register_safe_library]); here we
+   only drive them, maintaining library.ml's bookkeeping tables, and dispatch
+   full- vs safe-mode registration for each library of a required closure. *)
+
+let register_safe_library_syntax ~root m =
+  Declaremods.Synterp.register_safe_library m.library_name
+    (Safe_typing.module_of_library m.library_data.md_compiled);
+  register_loaded_library ~root SafeLoaded m
+
+let register_safe_library m =
+  let compiled = m.library_data.md_compiled in
+  let () =
+    let mp = MPfile m.library_name in
+    try
+      (* If the library was loaded inside a module or section, the
+         end_segment will replay the library object for non-kernel
+         effects but the kernel did not forget the library. *)
+      ignore(Global.lookup_module mp);
+    with Not_found ->
+      let mp' = Global.import compiled m.library_vm m.library_digests in
+      if not (ModPath.equal mp mp') then
+        anomaly (Pp.str "Unexpected disk module name.")
+  in
+  Declaremods.Interp.register_safe_library m.library_name
+    (Safe_typing.module_of_library compiled);
+  register_native_library m.library_name
+
+(* Unified require objects. A single [Require] / [Require (safe)] now
+   registers a whole topologically-ordered closure in which each library
+   carries its computed mode: full libraries replay their objects, safe ones
+   are only imported kernel-side. Interleaving the two in one object preserves
+   the order (a full library's object replay may rely on an earlier one). *)
+
+let register_one_syntax (mode, root, m) = match mode with
+  | ModeFull -> register_library_syntax ~root m
+  | ModeSafe -> register_safe_library_syntax ~root m
+
+let register_one_interp (mode, m) = match mode with
+  | ModeFull -> register_library m
+  | ModeSafe -> register_safe_library m
 
 (* Follow the semantics of Anticipate object:
    - called at module or module type closing when a Require occurs in
@@ -402,14 +551,14 @@ let register_library_syntax (root, m) =
    - not called from a library (i.e. a module identified with a file)
    [needed] is the ordered list of libraries not already loaded *)
 let cache_require needed =
-  List.iter register_library needed
+  List.iter register_one_interp needed
 
 let load_require _ o =
   cache_require o
 
 (* open_function is never called from here because an Anticipate object *)
 
-type require_obj = library_t list
+type require_obj = (require_mode * library_t) list
 
 let in_require : require_obj -> obj =
   declare_object
@@ -421,14 +570,14 @@ let in_require : require_obj -> obj =
      classify_function = (fun o -> Anticipate) }
 
 let cache_require_syntax needed =
-  List.iter register_library_syntax needed
+  List.iter register_one_syntax needed
 
 let load_require_syntax _ o =
   cache_require_syntax o
 
 (* open_function is never called from here because an Anticipate object *)
 
-type require_obj_syntax = (bool * library_t) list
+type require_obj_syntax = (require_mode * bool * library_t) list
 
 let in_require_syntax : require_obj_syntax -> obj =
   declare_object
@@ -452,83 +601,10 @@ let require_library needed =
   if Lib.is_module_or_modtype () then warn_require_in_module ();
   Lib.add_leaf (in_require needed)
 
-let require_library_syntax_from_dirpath ~intern modrefl =
-  let needed, contents = List.fold_left (rec_intern_library ~safe:false ~intern) ([], DirPath.Map.empty) modrefl in
-  let needed = List.rev_map (fun (root, dir) -> root, DirPath.Map.find dir contents) needed in
+let require_library_syntax_from_dirpath ~cmd_safe ~intern modrefl =
+  let needed = intern_and_resolve_modes ~cmd_safe ~intern modrefl in
   Lib.add_leaf (in_require_syntax needed);
-  List.map snd needed
-
-(* safe require: the kernel-side import and the name-pushing walk live in
-   declaremods.ml (see [Declaremods.*.register_safe_library]); here we only
-   drive them and maintain library.ml's bookkeeping tables. *)
-
-let cache_one_safe_require_synterp (root, m) =
-  Declaremods.Synterp.register_safe_library m.library_name
-    (Safe_typing.module_of_library m.library_data.md_compiled);
-  register_loaded_library ~root SafeLoaded m
-
-let cache_one_safe_require_interp m =
-  let compiled = m.library_data.md_compiled in
-  let () =
-    let mp = MPfile m.library_name in
-    try
-      (* If the library was loaded inside a module or section, the
-         end_segment will replay the library object for non-kernel
-         effects but the kernel did not forget the library. *)
-      ignore(Global.lookup_module mp);
-    with Not_found ->
-      let mp' = Global.import compiled m.library_vm m.library_digests in
-      if not (ModPath.equal mp mp') then
-        anomaly (Pp.str "Unexpected disk module name.")
-  in
-  Declaremods.Interp.register_safe_library m.library_name
-    (Safe_typing.module_of_library compiled);
-  register_native_library m.library_name
-
-let cache_safe_require_synterp needed =
-  List.iter cache_one_safe_require_synterp needed
-
-let load_safe_require_synterp _ o =
-  cache_safe_require_synterp o
-
-type safe_require_synterp = (bool * library_t) list
-
-let in_safe_require_synterp : safe_require_synterp -> obj =
-  declare_object
-    {(default_object "SAFE-REQUIRE-SYNTERP") with
-     object_stage = Summary.Stage.Synterp;
-     cache_function = cache_safe_require_synterp;
-     load_function = load_safe_require_synterp;
-     open_function = (fun _ _ -> assert false);
-     discharge_function = (fun o -> Some o);
-     classify_function = (fun o -> Anticipate) }
-
-let cache_safe_require_interp needed =
-  List.iter cache_one_safe_require_interp needed
-
-let load_safe_require_interp _ o = cache_safe_require_interp o
-
-type safe_require_interp = library_t list
-
-let in_safe_require_interp : safe_require_interp -> obj =
-  declare_object
-    {(default_object "SAFE-REQUIRE-INTERP") with
-     object_stage = Summary.Stage.Interp;
-     cache_function = cache_safe_require_interp;
-     load_function = load_safe_require_interp;
-     open_function = (fun _ _ -> assert false);
-     discharge_function = (fun o -> Some o);
-     classify_function = (fun o -> Anticipate) }
-
-let safe_require_synterp ~intern modrefl =
-  let needed, contents = List.fold_left (rec_intern_library ~safe:true ~intern) ([], DirPath.Map.empty) modrefl in
-  let needed = List.rev_map (fun (root, dir) -> root, DirPath.Map.find dir contents) needed in
-  Lib.add_leaf (in_safe_require_synterp needed);
-  List.map snd needed
-
-let safe_require_interp needed =
-  if Lib.is_module_or_modtype () then warn_require_in_module ();
-  Lib.add_leaf (in_safe_require_interp needed)
+  List.map (fun (mode, _root, m) -> (mode, m)) needed
 
 (************************************************************************)
 (*s [save_library dir] ends library [dir] and save it to the disk. *)
@@ -542,6 +618,18 @@ let current_deps () =
     else None
   in
   List.map_filter map !libraries_loaded_list
+
+let current_safe_deps () =
+  (* Among the direct dependencies (the roots of the DAG), record those that
+     are only safe-loaded so that downstream requires keep them safe. *)
+  let add acc (root, m) =
+    if root then
+      match find_library m with
+      | Some (SafeLoaded, _) -> DirPath.Set.add m acc
+      | Some (FullLoaded, _) | None -> acc
+    else acc
+  in
+  List.fold_left add DirPath.Set.empty !libraries_loaded_list
 
 let error_recursively_dependent_library dir =
   user_err
@@ -588,6 +676,7 @@ let save_library_struct ~output_native_objects dir =
     ; md_deps = Array.of_list (current_deps ())
     ; md_ocaml = Coq_config.caml_version
     ; md_info = info
+    ; md_safe_deps = current_safe_deps ()
     } in
   let md =
     { md_compiled

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -21,11 +21,14 @@ open Names
 (** Type of libraries loaded in memory *)
 type library_t
 
+(** Whether a library of a required closure is fully loaded (its objects are
+    replayed) or only safe-loaded (imported kernel-side, full-qualified names
+    only). *)
+type require_mode = ModeFull | ModeSafe
+
 (** {6 ... }
     Require = load in the environment *)
-val require_library : library_t list -> unit
-
-val safe_require_interp : library_t list -> unit
+val require_library : (require_mode * library_t) list -> unit
 
 (** Intern from a .vo file located by libresolver *)
 module Intern : sig
@@ -41,15 +44,15 @@ end
 val intern_from_file : CUnix.physical_path ->
   (library_t, Exninfo.iexn) Result.t * Intern.Provenance.t
 
+(** Intern the dependency closure of the given roots, compute per-library
+    modes ([cmd_safe] is the command mode: [false] for [Require], [true] for
+    [Require (safe)]), register the syntactic part and return the interp-side
+    closure tagged with the computed modes. *)
 val require_library_syntax_from_dirpath
-  : intern:Intern.t
+  : cmd_safe:bool
+  -> intern:Intern.t
   -> DirPath.t Loc.located list
-  -> library_t list
-
-val safe_require_synterp
-  : intern:Intern.t ->
-  DirPath.t Loc.located list ->
-  library_t list
+  -> (require_mode * library_t) list
 
 (** {6 Start the compilation of a library } *)
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1393,14 +1393,19 @@ let pr_synterp_vernac_expr v =
     return (
       keyword "Declare Custom Entry " ++ Id.print s
     )
-  | VernacSafeRequire (from, l) ->
+  | VernacSafeRequire (from, exp, l) ->
     let from = match from with
       | None -> mt ()
       | Some r -> keyword "From" ++ spc () ++ pr_module r ++ spc ()
     in
+    let exp = match exp with
+      | None -> mt ()
+      | Some export -> pr_export_flag export ++ spc ()
+    in
     return (
       hov 2
-        (from ++ keyword "Require" ++ str "(safe)" ++ spc() ++ prlist_with_sep sep pr_qualid l)
+        (from ++ keyword "Require" ++ str "(safe)" ++ spc() ++ exp ++
+         prlist_with_sep sep pr_qualid l)
     )
   | VernacRequire (from, exp, l) ->
     let from = match from with

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -55,7 +55,7 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of lident
   | EVernacEndSegment of lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * qualid list
+  | EVernacSafeRequire of Library.library_t list * DirPath.t list * export_flag option * qualid list
   | EVernacRequire of
       Library.library_t list * DirPath.t list * export_with_cats option * (qualid * import_filter_expr) list
   | EVernacImport of (export_flag *
@@ -314,10 +314,18 @@ let require_locate from qidl =
       | Error LibNotFound -> Loc.raise ?loc:qid.loc (NotFoundLibrary (root, qid)))
     qidl
 
-let synterp_safe_require ~intern from qidl =
+let synterp_safe_require ~intern from export qidl =
   let modrefl = require_locate from qidl in
   Coq_config.gc_ramp_up @@ fun () ->
   let needed = Library.safe_require_synterp ~intern modrefl in
+  (* Import/Export goes through the standard [import_module] path: our
+     hook in Declaremods pushes the short names of a safe-loaded library,
+     and [Export] records the usual [ExportObject] for re-export. *)
+  Option.iter (fun export ->
+      List.iter (fun (_, m) ->
+          Declaremods.Synterp.import_module Libobject.unfiltered ~export (MPfile m))
+        modrefl)
+    export;
   needed, List.map snd modrefl
 
 let synterp_require ~intern from export qidl =
@@ -420,9 +428,9 @@ let rec synterp ~intern ?loc ~atts v =
     | VernacEndSegment lid ->
       synterp_end_segment lid;
       EVernacEndSegment lid
-    | VernacSafeRequire (from, qidl) ->
-      let needed, modrefl = synterp_safe_require ~intern from qidl in
-      EVernacSafeRequire (needed, modrefl, qidl)
+    | VernacSafeRequire (from, export, qidl) ->
+      let needed, modrefl = synterp_safe_require ~intern from export qidl in
+      EVernacSafeRequire (needed, modrefl, export, qidl)
     | VernacRequire (from, export, qidl) ->
       let needed, modrefl = synterp_require ~intern from export qidl in
       EVernacRequire (needed, modrefl, export, qidl)

--- a/vernac/synterp.ml
+++ b/vernac/synterp.ml
@@ -55,9 +55,9 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of lident
   | EVernacEndSegment of lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * export_flag option * qualid list
+  | EVernacSafeRequire of (Library.require_mode * Library.library_t) list * DirPath.t list * export_flag option * qualid list
   | EVernacRequire of
-      Library.library_t list * DirPath.t list * export_with_cats option * (qualid * import_filter_expr) list
+      (Library.require_mode * Library.library_t) list * DirPath.t list * export_with_cats option * (qualid * import_filter_expr) list
   | EVernacImport of (export_flag *
       Libobject.open_filter) *
       (Names.ModPath.t CAst.t * import_filter_expr) list
@@ -317,7 +317,7 @@ let require_locate from qidl =
 let synterp_safe_require ~intern from export qidl =
   let modrefl = require_locate from qidl in
   Coq_config.gc_ramp_up @@ fun () ->
-  let needed = Library.safe_require_synterp ~intern modrefl in
+  let needed = Library.require_library_syntax_from_dirpath ~cmd_safe:true ~intern modrefl in
   (* Import/Export goes through the standard [import_module] path: our
      hook in Declaremods pushes the short names of a safe-loaded library,
      and [Export] records the usual [ExportObject] for re-export. *)
@@ -331,14 +331,14 @@ let synterp_safe_require ~intern from export qidl =
 let synterp_require ~intern from export qidl =
   let modrefl = require_locate from (List.map fst qidl) in
   Coq_config.gc_ramp_up @@ fun () ->
-  let filenames = Library.require_library_syntax_from_dirpath ~intern modrefl in
+  let needed = Library.require_library_syntax_from_dirpath ~cmd_safe:false ~intern modrefl in
   Option.iter (fun (export,cats) ->
       let cats = synterp_import_cats cats in
       List.iter2 (fun (_, m) (_, f) ->
           import_module_syntax_with_filter ~export cats (MPfile m) f)
         modrefl qidl)
     export;
-    filenames, List.map snd modrefl
+    needed, List.map snd modrefl
 
 (*****************************)
 (* Auxiliary file management *)

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -32,7 +32,7 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of Names.lident
   | EVernacEndSegment of Names.lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * qualid list
+  | EVernacSafeRequire of Library.library_t list * DirPath.t list * Vernacexpr.export_flag option * qualid list
   | EVernacRequire of
       Library.library_t list * DirPath.t list * Vernacexpr.export_with_cats option * (qualid * Vernacexpr.import_filter_expr) list
   | EVernacImport of (Vernacexpr.export_flag * Libobject.open_filter) *

--- a/vernac/synterp.mli
+++ b/vernac/synterp.mli
@@ -32,9 +32,9 @@ type synterp_entry =
   | EVernacNotation of { local : bool; decl : Metasyntax.notation_interpretation_decl }
   | EVernacBeginSection of Names.lident
   | EVernacEndSegment of Names.lident
-  | EVernacSafeRequire of Library.library_t list * DirPath.t list * Vernacexpr.export_flag option * qualid list
+  | EVernacSafeRequire of (Library.require_mode * Library.library_t) list * DirPath.t list * Vernacexpr.export_flag option * qualid list
   | EVernacRequire of
-      Library.library_t list * DirPath.t list * Vernacexpr.export_with_cats option * (qualid * Vernacexpr.import_filter_expr) list
+      (Library.require_mode * Library.library_t) list * DirPath.t list * Vernacexpr.export_with_cats option * (qualid * Vernacexpr.import_filter_expr) list
   | EVernacImport of (Vernacexpr.export_flag * Libobject.open_filter) *
       (Names.ModPath.t CAst.t * Vernacexpr.import_filter_expr) list
   | EVernacDeclareMLModule of Mltop.interp_fun
@@ -74,7 +74,7 @@ val synterp_require :
   Libnames.qualid option ->
   Vernacexpr.export_with_cats option ->
   (Libnames.qualid * Vernacexpr.import_filter_expr) list ->
-  Library.library_t list * DirPath.t list
+  (Library.require_mode * Library.library_t) list * DirPath.t list
 
 (** [synterp_control] is the main entry point of the syntactic interpretation phase *)
 val synterp_control :

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1667,12 +1667,20 @@ let warn_require_in_section =
     (fun () -> strbrk "Use of “Require” inside a section is fragile." ++ spc() ++
                strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
-let vernac_safe_require_interp needed modrefl qidl =
-if Lib.sections_are_opened () then warn_require_in_section ();
+let vernac_safe_require_interp needed modrefl export qidl =
+  if Lib.sections_are_opened () then warn_require_in_section ();
   if Dumpglob.dump () then
     List.iter2 (fun {CAst.loc} dp -> Dumpglob.dump_libref ?loc dp "lib") qidl modrefl;
   Coq_config.gc_ramp_up @@ fun () ->
-  Library.safe_require_interp needed
+  (* Load (kernel import + fully-qualified names, no libobject replay) *)
+  Library.safe_require_interp needed;
+  (* Import/Export: goes through the standard [import_module] path, which
+     our Declaremods hook redirects to the safe short-name walk. *)
+  Option.iter (fun export ->
+      List.iter (fun m ->
+          import_module_with_filter ~export Libobject.unfiltered (MPfile m) ImportAll)
+        modrefl)
+    export
 
 let vernac_require_interp needed modrefl export qidl =
   if Lib.sections_are_opened () then warn_require_in_section ();
@@ -2718,10 +2726,10 @@ let translate_vernac_synterp ?loc ~atts v = let open Vernactypes in match v with
     unsupported_attributes atts;
     vernac_end_segment lid
 
-  | EVernacSafeRequire (needed, modrefl, qidl) ->
+  | EVernacSafeRequire (needed, modrefl, export, qidl) ->
     vtdefault (fun () ->
         unsupported_attributes atts;
-        vernac_safe_require_interp needed modrefl qidl)
+        vernac_safe_require_interp needed modrefl export qidl)
 
   | EVernacRequire (needed, modrefl, export, qidl) ->
     vtdefault(fun () ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1672,8 +1672,9 @@ let vernac_safe_require_interp needed modrefl export qidl =
   if Dumpglob.dump () then
     List.iter2 (fun {CAst.loc} dp -> Dumpglob.dump_libref ?loc dp "lib") qidl modrefl;
   Coq_config.gc_ramp_up @@ fun () ->
-  (* Load (kernel import + fully-qualified names, no libobject replay) *)
-  Library.safe_require_interp needed;
+  (* Load the closure (each library full- or safe-registered per its computed
+     mode) through the unified require object. *)
+  Library.require_library needed;
   (* Import/Export: goes through the standard [import_module] path, which
      our Declaremods hook redirects to the safe short-name walk. *)
   Option.iter (fun export ->

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -32,7 +32,7 @@ val vernac_require
 
 (** Interp phase of the require command *)
 val vernac_require_interp
-  : Library.library_t list
+  : (Library.require_mode * Library.library_t) list
   -> Names.DirPath.t list
   -> Vernacexpr.export_with_cats option
   -> (Libnames.qualid * Vernacexpr.import_filter_expr) list

--- a/vernac/vernacexpr.mli
+++ b/vernac/vernacexpr.mli
@@ -377,7 +377,7 @@ type synterp_vernac_expr =
   | VernacDeclareCustomEntry of Id.t
   | VernacBeginSection of lident
   | VernacEndSegment of lident
-  | VernacSafeRequire of qualid option * qualid list
+  | VernacSafeRequire of qualid option * export_flag option * qualid list
   | VernacRequire of
       qualid option * export_with_cats option * (qualid * import_filter_expr) list
   | VernacImport of export_with_cats * (qualid * import_filter_expr) list


### PR DESCRIPTION
Combined follow-up for rocq-prover/rocq#22291 against your `safrequire` branch: the Import/Export offer and the dep-propagation offer reconciled on one branch (they conflict — both restructure the safe-registration path).

Reconciliation: propagation's unified mode-dispatching require objects are the single mechanism; the ModeSafe path calls the relocated `Declaremods.{Synterp,Interp}.register_safe_library` (which also feeds the `SafeLibs` registry that Import/Export needs — including for safe libs pulled in transitively by a plain `Require`). `VernacSafeRequire` carries both the export flag and mode-annotated interning results.

The combination unlocks an integration test impossible on either branch alone (misc/safe-require-export-import): A.v does `Require (safe) Export CRelationClasses`; B.v does `Require A` then `Import A` — the ExportObject replay hits the safe path downstream because propagation kept the lib safe in B's session, and short names appear while the lib stays safe (verified to fail on the import-export branch alone, where `Require A` fully loads the dep).

All green: `make world`, base SafeRequire + SafeRequireImport + propagation tests + the new integration test, full modules/coqchk/misc/output groups.

Supersedes the two individual PRs if you want both features.

Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
